### PR TITLE
Make requests optional in template tags

### DIFF
--- a/docs/api/jinja2.md
+++ b/docs/api/jinja2.md
@@ -32,6 +32,8 @@ Returns `True` if a flag is enabled by for the given request, otherwise returns 
 {% endif %}
 ```
 
+`request` is optional.
+
 ### `flag_disabled`
 
 Returns `True` if a flag is disabled by passing the current request to its conditions, otherwise returns `False`.
@@ -44,3 +46,5 @@ Returns `True` if a flag is disabled by for the given request, otherwise returns
   </div>
 {% endif %}
 ```
+
+`request` is optional.

--- a/flags/template_functions.py
+++ b/flags/template_functions.py
@@ -4,11 +4,11 @@ from flags.state import (
 )
 
 
-def flag_enabled(flag_name, request):
+def flag_enabled(flag_name, request=None):
     """ Check if a flag is enabled for a given request """
     return base_flag_enabled(flag_name, request=request)
 
 
-def flag_disabled(flag_name, request):
+def flag_disabled(flag_name, request=None):
     """ Check if a flag is disabled for a given request """
     return base_flag_disabled(flag_name, request=request)

--- a/flags/templatetags/feature_flags.py
+++ b/flags/templatetags/feature_flags.py
@@ -17,11 +17,11 @@ else:  # pragma: no cover
 
 @simple_tag(takes_context=True)
 def flag_enabled(context, flag_name):
-    request = context['request']
+    request = context.get('request', None)
     return base_flag_enabled(flag_name, request=request)
 
 
 @simple_tag(takes_context=True)
 def flag_disabled(context, flag_name):
-    request = context['request']
+    request = context.get('request', None)
     return base_flag_disabled(flag_name, request=request)

--- a/flags/tests/test_forms.py
+++ b/flags/tests/test_forms.py
@@ -30,7 +30,7 @@ class FormTestCase(TestCase):
     def test_condition_choices_are_bound_late(self):
         @register('fake_condition')
         def fake_condition():
-            return True
+            return True  # pragma: no cover
 
         def cleanup_condition(condition_name):
             del CONDITIONS[condition_name]

--- a/flags/tests/test_template_functions.py
+++ b/flags/tests/test_template_functions.py
@@ -14,8 +14,14 @@ class TemplateFunctionsTestCase(TestCase):
     def test_flag_enabled_false(self):
         self.assertFalse(flag_enabled('FLAG_DISABLED', request=self.request))
 
+    def test_flag_enabled_no_request(self):
+        self.assertTrue(flag_enabled('FLAG_ENABLED'))
+
     def test_flag_disabled_true(self):
         self.assertTrue(flag_disabled('FLAG_DISABLED', request=self.request))
 
     def test_flag_disabled_false(self):
         self.assertFalse(flag_disabled('FLAG_ENABLED', request=self.request))
+
+    def test_flag_disabled_no_request(self):
+        self.assertTrue(flag_disabled('FLAG_DISABLED'))

--- a/flags/tests/test_templatetags_feature_flags.py
+++ b/flags/tests/test_templatetags_feature_flags.py
@@ -50,6 +50,19 @@ class FlagsTemplateTagsTestCase(TestCase):
         )
         self.assertEqual(rendered, 'flag enabled')
 
+    def test_flag_enabled_no_request(self):
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flag_enabled "FLAG_ENABLED"  as test_flag %}'
+            '{% if test_flag %}'
+            'flag enabled'
+            '{% else %}'
+            'flag disabled'
+            '{% endif %}',
+            context={}
+        )
+        self.assertEqual(rendered, 'flag enabled')
+
     def test_flag_disabled_disabled(self):
         # Disabled can also mean non-existent
         rendered = self.render_template(
@@ -60,6 +73,20 @@ class FlagsTemplateTagsTestCase(TestCase):
             '{% else %}'
             'flag enabled'
             '{% endif %}'
+        )
+        self.assertEqual(rendered, 'flag disabled')
+
+    def test_flag_disabled_no_request(self):
+        # Disabled can also mean non-existent
+        rendered = self.render_template(
+            '{% load feature_flags %}'
+            '{% flag_disabled "FLAG_DISABLED"  as test_flag %}'
+            '{% if test_flag %}'
+            'flag disabled'
+            '{% else %}'
+            'flag enabled'
+            '{% endif %}',
+            context={}
         )
         self.assertEqual(rendered, 'flag disabled')
 

--- a/flags/urls.py
+++ b/flags/urls.py
@@ -118,9 +118,9 @@ def _flagged_path(flag_name, route, view, kwargs=None, name=None,
                                   state,
                                   fallback=fallback)(view)
 
-        if Pattern:
+        if Pattern:  # pragma: no cover
             route_pattern = Pattern(route, name=name, is_endpoint=True)
-        else:
+        else:  # pragma: no cover
             route_pattern = route
 
         return URLPattern(route_pattern, flagged_view, kwargs, name)
@@ -128,9 +128,9 @@ def _flagged_path(flag_name, route, view, kwargs=None, name=None,
     elif isinstance(view, (list, tuple)):
         urlconf_module, app_name, namespace = view
 
-        if Pattern:
+        if Pattern:  # pragma: no cover
             route_pattern = Pattern(route, name=name, is_endpoint=True)
-        else:
+        else:  # pragma: no cover
             route_pattern = route
 
         return FlaggedURLResolver(


### PR DESCRIPTION
This PR makes a slight change to both Django and Jinja2 template tags/functions to make the `request` optional. In Django templates, `request` will not be assumed to be in the `context`, and in Jinja2 templates, the `request` argument is now optional.

Some conditions still require the `request` to be evaluated, but those conditions will raise `RequiredForCondition` if it is not given.

This PR also bumps the version to 3.0.1 in anticipation of release once it's merged.

This should close https://github.com/cfpb/wagtail-flags/issues/30