### PR TITLE
Bind condition choices when admin form is created

### DIFF
--- a/flags/forms.py
+++ b/flags/forms.py
@@ -8,15 +8,20 @@ from flags.settings import get_flags
 class FlagStateForm(forms.ModelForm):
 
     FLAGS_CHOICES = [(flag, flag) for flag in sorted(get_flags().keys())]
-    CONDITIONS_CHOICES = [(c, c) for c in sorted(get_conditions())]
 
     name = forms.ChoiceField(choices=FLAGS_CHOICES,
                              label="Flag",
                              required=True)
-    condition = forms.ChoiceField(choices=CONDITIONS_CHOICES,
-                                  label="Is enabled when",
+    condition = forms.ChoiceField(label="Is enabled when",
                                   required=True)
     value = forms.CharField(label="Is", required=True)
+
+    def __init__(self, *args, **kwargs):
+        super(FlagStateForm, self).__init__(*args, **kwargs)
+
+        self.fields['condition'].choices = [
+            (c, c) for c in sorted(get_conditions())
+        ]
 
     class Meta:
         model = FlagState

--- a/flags/tests/test_forms.py
+++ b/flags/tests/test_forms.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
 
+from flags.conditions import CONDITIONS, register
 from flags.forms import FlagStateForm
 
 
@@ -25,3 +26,19 @@ class FormTestCase(TestCase):
             'condition': ['This field is required.'],
             'value': ['This field is required.'],
         })
+
+    def test_condition_choices_are_bound_late(self):
+        @register('fake_condition')
+        def fake_condition():
+            return True
+
+        def cleanup_condition(condition_name):
+            del CONDITIONS[condition_name]
+
+        self.addCleanup(cleanup_condition, 'fake_condition')
+
+        form = FlagStateForm()
+        self.assertIn(
+            ('fake_condition', 'fake_condition'),
+            form.fields['condition'].choices
+        )


### PR DESCRIPTION
Previously, the FlagStateForm condition choices were bound
when the module was loaded. It is possible for this happen
before custom conditions in other Django apps have been
registered.

This commit delays populating the choices until the form is
created. This allows all custom conditions to be registered
first.