### PR TITLE
Remove deprecated github markdown extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -17,7 +17,10 @@ extra_css:
     - css/overrides.css
 markdown_extensions:
     - tables
-    - pymdownx.github
+    - markdown.extensions.tables
+    - pymdownx.magiclink
+    - pymdownx.betterem
+    - pymdownx.tilde
     - pymdownx.superfences
     - toc:
         permalink: "¶"


### PR DESCRIPTION
PyMdown Extensions deprecated the GitHub extension. Replace it with the extensions that it included that we're most interested in.

This should fix the daily build of master.