### PR TITLE
Allow user_condition to work with custom user models

### DIFF
--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -1,8 +1,6 @@
 import re
 
 import django
-from django.apps import apps
-from django.core.exceptions import ObjectDoesNotExist
 from django.utils import dateparse, timezone
 
 
@@ -68,11 +66,7 @@ def user_condition(username, request=None, **kwargs):
         raise RequiredForCondition("request is required for condition "
                                    "'user'")
 
-    User = apps.get_model('auth', 'User')
-    try:
-        return request.user == User.objects.get(username=username)
-    except ObjectDoesNotExist:
-        return False
+    return request.user.get_username() == username
 
 
 @register('anonymous')

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -17,6 +17,7 @@ from flags.conditions import (
     register,
     user_condition,
 )
+from mock import MagicMock
 
 
 class ConditionRegistryTestCase(TestCase):
@@ -79,6 +80,13 @@ class UserConditionTestCase(TestCase):
     def test_request_required(self):
         with self.assertRaises(RequiredForCondition):
             user_condition('testuser')
+
+    def test_with_custom_user(self):
+        mock_user = MagicMock()
+        mock_user.get_username.return_value = 'test@test.com'
+        self.request.user = mock_user
+
+        self.assertTrue(user_condition('test@test.com', request=self.request))
 
 
 class AnonymousConditionTestCase(TestCase):


### PR DESCRIPTION
Previously, `user_condition` was assuming that the default
User model was being used. This causes an error in projects
using custom user models.

Instead of taking the hit of loading the user record from
the database again within the condition, we should be able
to just compare the provided username against the user
instance that is already attached to the request.

Both the `AbstractBaseUser` and `AnonymousUser` implement a
`get_username()` function so it should be safe to rely on
that.