### PR TITLE
Add caching for flag conditions

### DIFF
--- a/docs/css/overrides.css
+++ b/docs/css/overrides.css
@@ -27,7 +27,8 @@ a:hover,
 .wy-menu-vertical .caption-text {
     color: #ffffff;
 }
-.wy-menu-vertical li.current .subnav a {
+.wy-menu-vertical li.current .subnav a,
+.wy-menu-vertical .subnav li.current a {
     color: #101820;
 }
 .wy-nav-side {

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,34 @@
+# Settings
+
+## Defining flags
+
+### `FLAGS`
+
+Default: `{}`
+
+A dictionary of available feature flags and optional conditions. Flags must be defined in this dictionary to be available in the Django Admin for users to add and remove conditions that way.
+
+This dictionary takes the following format:
+
+```python
+FLAGS = {
+  'FLAG_WITH_EMPTY_CONDITIONS': {}
+  'FLAG_WITH_CONDITIONS': {
+    'condition name': 'value flag is expected to match to be enabled',
+  }
+}
+```
+
+## Caching flag conditions
+
+### `FLAGS_CACHE_CONDITIONS`
+
+Default: `False`
+
+When set to `True`, Django-Flags will store conditions in the default [Django Cache](https://docs.djangoproject.com/en/2.1/topics/cache/#setting-up-the-cache). Saving or deleting a condition in the Django admin will invalidate the cache. 
+
+### `FLAGS_CACHE_KEY` 
+
+Default: `'flags'`
+
+When `FLAGS_CACHE_CONDITIONS` is `True`, the `FLAGS_CACHE_KEY` string will be the key used to cache flag conditions. 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -16,7 +16,7 @@ FLAGS = {
 
 The set of conditions can be none (flag will never be enabled), one (only condition that has to be met for the flag to be enabled), or many (all have to be met for the flag to be enabled).
 
-Additional conditions can be added in the Django admin for any defined flag (illustrated in [Usage](#usage)). Conditions added in the Django admin can be changed without restarting Django, conditions defined in `settings.py` cannot. See below [for a list of built-in conditions](#built-in-conditions).
+Additional conditions can be added in the Django admin for any defined flag (illustrated in [Quickstart](../#quickstart)). Conditions added in the Django admin can be changed without restarting Django, conditions defined in `settings.py` cannot. See [the list of built-in conditions](conditions).
 
 ## Using flags in code
 
@@ -41,7 +41,7 @@ Django templates:
 {% endif %}
 ```
 
-Jinja2 templates (after [adding `flag_enabled` to the Jinja2 environment](#jinja2-templates)):
+Jinja2 templates (after [adding `flag_enabled` to the Jinja2 environment](api/jinja2/)):
 
 ```jinja
 {% if flag_enabled('MY_FLAG', request) %}
@@ -71,4 +71,22 @@ urlpatterns = [
 ]
 ```
 
-See the [API documentation below](#api) for more details and examples.
+See the [API reference](/api/state) for more details and examples.
+
+## Defining flags
+
+### `FLAGS`
+
+Default: `{}`
+
+
+## Caching flag conditions
+
+It is possible that a request cycle could check numerous flags, or check a single flag multiple times. Because flag conditions created in the Django admin are stored in the database, this can result in multiple identical database queries. To cache flag conditions with a cache key of `flags_conditions`:
+
+```python
+FLAGS_CACHE_CONDITIONS = True
+FLAGS_CACHE_KEY = 'flags_conditions'
+```
+
+See the [Settings reference](settings/) for more details.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -82,7 +82,7 @@ Default: `{}`
 
 ## Caching flag conditions
 
-It is possible that a request cycle could check numerous flags, or check a single flag multiple times. Because flag conditions created in the Django admin are stored in the database, this can result in multiple identical database queries. To cache flag conditions with a cache key of `flags_conditions`:
+It is possible that a request cycle could check numerous flags, or check a single flag multiple times. Because flag conditions created in the Django admin are stored in the database, this can result in multiple identical database queries. The default cache key is `flags`. To enable caching of flag conditions with a cache key of `flags_conditions`:
 
 ```python
 FLAGS_CACHE_CONDITIONS = True

--- a/flags/apps.py
+++ b/flags/apps.py
@@ -1,4 +1,6 @@
 from django.apps import AppConfig
+from django.conf import settings
+from django.core.cache import cache
 
 from flags.settings import add_flags_from_sources
 
@@ -8,4 +10,8 @@ class DjangoFlagsConfig(AppConfig):
     verbose_name = 'Django Flags'
 
     def ready(self):
+        # Clear any cached flag conditions
+        FLAGS_CACHE_KEY = getattr(settings, 'FLAGS_CACHE_KEY', 'flags')
+        cache.delete(FLAGS_CACHE_KEY)
+
         add_flags_from_sources()

--- a/flags/models.py
+++ b/flags/models.py
@@ -1,4 +1,8 @@
+from django.conf import settings
+from django.core.cache import cache
 from django.db import models
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
 
 
 class FlagState(models.Model):
@@ -13,3 +17,12 @@ class FlagState(models.Model):
     def __str__(self):
         return "{name} is enabled when {condition} is {value}".format(
             name=self.name, condition=self.condition, value=self.value)
+
+
+@receiver(post_save, sender=FlagState)
+@receiver(post_delete, sender=FlagState)
+def invalidate_cached_flag_conditions(sender, instance, **kwargs):
+    FLAGS_CACHE_CONDITIONS = getattr(settings, 'FLAGS_CACHE_CONDITIONS', False)
+    FLAGS_CACHE_KEY = getattr(settings, 'FLAGS_CACHE_KEY', 'flags')
+    if FLAGS_CACHE_CONDITIONS:
+        cache.delete(FLAGS_CACHE_KEY)

--- a/flags/settings.py
+++ b/flags/settings.py
@@ -2,6 +2,7 @@ from importlib import import_module
 
 from django.apps import apps
 from django.conf import settings
+from django.core.cache import cache
 from django.utils.functional import cached_property
 
 from flags.conditions import get_condition
@@ -19,9 +20,9 @@ class DuplicateFlagException(Exception):
 class Flag:
     """ A simple wrapper around feature flags and their conditions """
 
-    def __init__(self, name, conditions={}):
+    def __init__(self, name, configured_conditions={}):
         self.name = name
-        self.__conditions = conditions
+        self.__configured_conditions = configured_conditions
 
     def __eq__(self, other):
         """ There can be only one feature flag of a given name """
@@ -31,29 +32,35 @@ class Flag:
     def configured_conditions(self):
         """ Get all flag conditions configured in settings """
         # Get condition callables for our settings-configured conditions
-        condition_fns = [(c, fn, v, None)
-                         for c, v in self.__conditions.items()
-                         for fn in get_condition(c)]
-        return condition_fns
+        conditions = [
+            (c, v, None)
+            for c, v in self.__configured_conditions.items()
+        ]
+        return conditions
 
-    @cached_property
+    @property
     def dynamic_conditions(self):
         """ Get dynamic flag conditions from models.FlagState """
         # Get condition callables for our dynamic-configured conditions
         FlagState = apps.get_model('flags', 'FlagState')
-        condition_fns = [(s.condition, fn, s.value, s)
-                         for s in FlagState.objects.filter(name=self.name)
-                         for fn in get_condition(s.condition)]
-        return condition_fns
+        conditions = [
+            (s.condition, s.value, s)
+            for s in FlagState.objects.filter(name=self.name)
+        ]
+        return conditions
 
-    @cached_property
+    @property
     def conditions(self):
         """ Get all flag conditions """
         return self.configured_conditions + self.dynamic_conditions
 
     def check_state(self, **kwargs):
         """ Determine this flag's state based on any of its conditions """
-        return any(fn(v, **kwargs) for c, fn, v, o in self.conditions)
+        return any(
+            fn(v, **kwargs)
+            for c, v, o in self.conditions
+            for fn in get_condition(c)
+        )
 
 
 def add_flags_from_sources(sources=None):
@@ -74,17 +81,32 @@ def add_flags_from_sources(sources=None):
                 raise DuplicateFlagException("{} duplicated in {}".format(
                     flag, source_str))
 
+            cache.delete('flags_conditions_' + flag)
             SOURCED_FLAGS[flag] = getattr(source, flag)
 
 
 def get_flags(sourced_flags=None):
     """ Get a dictionary of Flag objects for all flags.
     This combines FLAGS from settings with all possible FLAG_SOURCES. """
-    flags_spec = getattr(settings, 'FLAGS', {})
-    if sourced_flags is None:
-        sourced_flags = SOURCED_FLAGS
-    flags_spec.update(sourced_flags)
+    FLAGS_CACHE_CONDITIONS = getattr(settings, 'FLAGS_CACHE_CONDITIONS', False)
+    FLAGS_CACHE_KEY = getattr(settings, 'FLAGS_CACHE_KEY', 'flags')
+    flags = None
 
-    flags = {name: Flag(name, conditions=conditions)
-             for name, conditions in flags_spec.items()}
+    if FLAGS_CACHE_CONDITIONS:
+        flags = cache.get(FLAGS_CACHE_KEY)
+
+    if flags is None:
+        flags_spec = getattr(settings, 'FLAGS', {})
+        if sourced_flags is None:
+            sourced_flags = SOURCED_FLAGS
+
+        flags_spec.update(sourced_flags)
+        flags = {
+            name: Flag(name, configured_conditions=conditions)
+            for name, conditions in flags_spec.items()
+        }
+
+        if FLAGS_CACHE_CONDITIONS:
+            cache.set(FLAGS_CACHE_KEY, flags)
+
     return flags

--- a/flags/settings.py
+++ b/flags/settings.py
@@ -87,7 +87,6 @@ def add_flags_from_sources(sources=None):
                 raise DuplicateFlagException("{} duplicated in {}".format(
                     flag, source_str))
 
-            cache.delete('flags_conditions_' + flag)
             SOURCED_FLAGS[flag] = getattr(source, flag)
 
 

--- a/flags/settings.py
+++ b/flags/settings.py
@@ -33,7 +33,10 @@ class Flag:
         """ Get all flag conditions configured in settings """
         # Get condition callables for our settings-configured conditions
         conditions = [
-            (c, v, None)
+            # Previously, this tuple was (condition, fn, value, obj).
+            # The fn is fetched in `check_state` now, but the position is
+            # being preserved for API-compatibility until 4.0.
+            (c, None, v, None)
             for c, v in self.__configured_conditions.items()
         ]
         return conditions
@@ -44,7 +47,10 @@ class Flag:
         # Get condition callables for our dynamic-configured conditions
         FlagState = apps.get_model('flags', 'FlagState')
         conditions = [
-            (s.condition, s.value, s)
+            # Previously, this tuple was (condition, fn, value, obj).
+            # The fn is fetched in `check_state` now, but the position is
+            # being preserved for API-compatibility until 4.0.
+            (s.condition, None, s.value, s)
             for s in FlagState.objects.filter(name=self.name)
         ]
         return conditions
@@ -58,7 +64,7 @@ class Flag:
         """ Determine this flag's state based on any of its conditions """
         return any(
             fn(v, **kwargs)
-            for c, v, o in self.conditions
+            for c, n, v, o in self.conditions
             for fn in get_condition(c)
         )
 

--- a/flags/tests/test_models.py
+++ b/flags/tests/test_models.py
@@ -1,12 +1,41 @@
-from django.test import TestCase
+from django.core.cache import cache
+from django.test import TestCase, override_settings
 
 from flags.models import FlagState
 
 
 class FlagStateTestCase(TestCase):
+
     def test_flag_str(self):
-        state = FlagState.objects.create(name='MY_FLAG',
-                                         condition='boolean',
-                                         value='True')
-        self.assertEqual(str(state),
-                         'MY_FLAG is enabled when boolean is True')
+        state = FlagState.objects.create(
+            name='MY_FLAG',
+            condition='boolean',
+            value='True'
+        )
+        self.assertEqual(
+            str(state),
+            'MY_FLAG is enabled when boolean is True'
+        )
+
+    @override_settings(FLAGS_CACHE_CONDITIONS=True)
+    def test_save_signal_receiver(self):
+        cache.set('flags', ('test conditions', 'value', None))
+        self.assertIsNotNone(cache.get('flags'))
+        FlagState.objects.create(
+            name='MY_FLAG',
+            condition='boolean',
+            value='True'
+        )
+        self.assertIsNone(cache.get('flags_conditions_MY_FLAG'))
+
+    @override_settings(FLAGS_CACHE_CONDITIONS=True)
+    def test_delete_signal_receiver(self):
+        state = FlagState.objects.create(
+            name='MY_FLAG',
+            condition='boolean',
+            value='True'
+        )
+        cache.set('flags', ('test conditions', 'value', None))
+        self.assertIsNotNone(cache.get('flags'))
+        state.delete()
+        self.assertIsNone(cache.get('flags'))

--- a/flags/tests/test_models.py
+++ b/flags/tests/test_models.py
@@ -26,7 +26,7 @@ class FlagStateTestCase(TestCase):
             condition='boolean',
             value='True'
         )
-        self.assertIsNone(cache.get('flags_conditions_MY_FLAG'))
+        self.assertIsNone(cache.get('flags'))
 
     @override_settings(FLAGS_CACHE_CONDITIONS=True)
     def test_delete_signal_receiver(self):

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,7 @@ repo_url: https://github.com/cfpb/django-flags/
 pages:
     - Getting started: index.md
     - Usage guide: usage.md
+    - Settings: settings.md
     - Built-in conditions: conditions.md
     - API Reference:
         - Flag state: api/state.md


### PR DESCRIPTION
Previously every time a database flag was checked it caused a database hit. This change caches all conditions so that won't happen, and deletes that cache when a database flag condition is either saved or deleted. This all depends on whether the `FLAGS_CACHE_CONDITIONS` setting is `True`.

This PR also updates the docs to document that setting and another that controls the name of the cache key. It also fixes some errors discovered in the docs.