### PR TITLE
Add middleware to attach flag conditions to the request

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,8 @@ matrix:
   include:
     - env: TOXENV=lint
       python: 3.6
-    - env: TOXENV=py27-dj18
-      python: 2.7
     - env: TOXENV=py27-dj111
       python: 2.7
-    - env: TOXENV=py36-dj18
-      python: 3.6
     - env: TOXENV=py36-dj111
       python: 3.6
     - env: TOXENV=py36-dj20

--- a/docs/api/state.md
+++ b/docs/api/state.md
@@ -12,7 +12,7 @@ from flags.state import (
 
 ### `flag_state(flag_name, **kwargs)`
 
-Return the value for the flag (`True` or `False`) by passing kwargs to its conditions.
+Return the value for the flag (`True` or `False`) by passing kwargs to its conditions. If the flag does not exist, this will return `None` so that existence can be introspected but will still evaluate to `False`.
 
 ## Requiring state
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,7 +25,7 @@ INSTALLED_APPS = (
 )
 ```
 
-And `django.template.context_processors.request` to the `TEMPLATES` `context_processors` setting:
+And `django.template.context_processors.request` to the `TEMPLATES` `context_processors` setting so that the `request` variable is available:
 
 ```python
 TEMPLATES = [
@@ -44,6 +44,16 @@ TEMPLATES = [
         # …
     },
 ]
+```
+
+(Optionally) add `flags.middleware.FlagConditionsMiddleware` to `MIDDLEWARE` to avoid looking up flag conditions more than once per request:
+
+```python
+MIDDLEWARE = (
+    # …
+    'flags.middleware.FlagConditionsMiddleware',
+    # …
+)
 ```
 
 Finally, run migrations:

--- a/flags/middleware.py
+++ b/flags/middleware.py
@@ -1,0 +1,13 @@
+from __future__ import absolute_import
+
+from flags.settings import get_flags
+
+
+class FlagConditionsMiddleware(object):
+    """
+    Simple middleware that adds all available feature flag conditions to the
+    request so that flag state can be checked.
+    """
+
+    def process_request(self, request):
+        request.FLAG_CONDITIONS = get_flags()

--- a/flags/middleware.py
+++ b/flags/middleware.py
@@ -1,13 +1,18 @@
 from __future__ import absolute_import
 
+from django.utils.deprecation import MiddlewareMixin
+
 from flags.settings import get_flags
 
 
-class FlagConditionsMiddleware(object):
+class FlagConditionsMiddleware(MiddlewareMixin):
     """
     Simple middleware that adds all available feature flag conditions to the
     request so that flag state can be checked.
     """
+    request_attribute = 'flag_conditions'
 
     def process_request(self, request):
-        request.FLAG_CONDITIONS = get_flags()
+        flags = get_flags()
+
+        setattr(request, self.request_attribute, flags)

--- a/flags/state.py
+++ b/flags/state.py
@@ -3,8 +3,16 @@ from flags.settings import get_flags
 
 def flag_state(flag_name, **kwargs):
     """ Return the value for the flag by passing kwargs to its conditions """
+
+    # If the request is given as a kwargs, and the FlagConditionsMiddleware is
+    # enabled, use the flag conditions attached to the request.
+    if hasattr(kwargs.get('request'), 'FLAG_CONDITIONS'):
+        conditions = kwargs['request'].FLAG_CONDITIONS
+    else:
+        conditions = get_flags()
+
     try:
-        return get_flags()[flag_name].check_state(**kwargs)
+        return conditions[flag_name].check_state(**kwargs)
     except KeyError:
         return False
 

--- a/flags/state.py
+++ b/flags/state.py
@@ -20,11 +20,11 @@ def flag_state(flag_name, **kwargs):
     if flags is None:
         flags = get_flags()
 
-    if flag_name not in flags:
-        return False
+    flag = flags.get(flag_name)
+    if flag is not None:
+        return flag.check_state(**kwargs)
 
-    flag = flags[flag_name]
-    return flag.check_state(**kwargs)
+    return None
 
 
 def flag_enabled(flag_name, **kwargs):

--- a/flags/state.py
+++ b/flags/state.py
@@ -1,20 +1,30 @@
+from __future__ import absolute_import
+
+from flags.middleware import FlagConditionsMiddleware
 from flags.settings import get_flags
 
 
 def flag_state(flag_name, **kwargs):
     """ Return the value for the flag by passing kwargs to its conditions """
+    flags = None
 
     # If the request is given as a kwargs, and the FlagConditionsMiddleware is
     # enabled, use the flag conditions attached to the request.
-    if hasattr(kwargs.get('request'), 'FLAG_CONDITIONS'):
-        conditions = kwargs['request'].FLAG_CONDITIONS
-    else:
-        conditions = get_flags()
+    if 'request' in kwargs:
+        flags = getattr(
+            kwargs['request'],
+            FlagConditionsMiddleware.request_attribute,
+            None
+        )
 
-    try:
-        return conditions[flag_name].check_state(**kwargs)
-    except KeyError:
+    if flags is None:
+        flags = get_flags()
+
+    if flag_name not in flags:
         return False
+
+    flag = flags[flag_name]
+    return flag.check_state(**kwargs)
 
 
 def flag_enabled(flag_name, **kwargs):

--- a/flags/tests/test_middleware.py
+++ b/flags/tests/test_middleware.py
@@ -1,0 +1,22 @@
+from django.test import RequestFactory, TestCase, override_settings
+
+from flags.middleware import FlagConditionsMiddleware
+
+
+@override_settings(
+    MIDDLEWARE=(
+        'flags.middleware.FlagConditionsMiddleware',
+    )
+)
+class FlagConditionsMiddlewareTestCase(TestCase):
+
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.middleware = FlagConditionsMiddleware()
+
+    def test_middleware(self):
+        request = self.factory.get('/test')
+        self.middleware.process_request(request)
+        self.assertIn('FLAG_ENABLED', request.FLAG_CONDITIONS)
+        self.assertIn('FLAG_DISABLED', request.FLAG_CONDITIONS)
+        self.assertIn('DB_FLAG', request.FLAG_CONDITIONS)

--- a/flags/tests/test_middleware.py
+++ b/flags/tests/test_middleware.py
@@ -1,22 +1,55 @@
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import (
+    RequestFactory,
+    SimpleTestCase,
+    TestCase,
+    override_settings,
+)
 
 from flags.middleware import FlagConditionsMiddleware
+from flags.state import flag_state
 
 
-@override_settings(
-    MIDDLEWARE=(
-        'flags.middleware.FlagConditionsMiddleware',
-    )
-)
-class FlagConditionsMiddlewareTestCase(TestCase):
-
+class FlagConditionsMiddlewareTestCase(SimpleTestCase):
     def setUp(self):
         self.factory = RequestFactory()
         self.middleware = FlagConditionsMiddleware()
 
-    def test_middleware(self):
+    def test_requests_without_middleware_attribute_is_undefined(self):
+        request = self.factory.get('/test')
+        self.assertFalse(hasattr(
+            request,
+            FlagConditionsMiddleware.request_attribute
+        ))
+
+    def test_middleware_defines_attribute(self):
         request = self.factory.get('/test')
         self.middleware.process_request(request)
-        self.assertIn('FLAG_ENABLED', request.FLAG_CONDITIONS)
-        self.assertIn('FLAG_DISABLED', request.FLAG_CONDITIONS)
-        self.assertIn('DB_FLAG', request.FLAG_CONDITIONS)
+        self.assertTrue(hasattr(
+            request,
+            FlagConditionsMiddleware.request_attribute
+        ))
+
+    def test_middleware_sets_attribute_with_flags(self):
+        request = self.factory.get('/test')
+        self.middleware.process_request(request)
+        flags = getattr(request, FlagConditionsMiddleware.request_attribute)
+        self.assertIn('FLAG_ENABLED', flags)
+        self.assertIn('FLAG_DISABLED', flags)
+        self.assertIn('DB_FLAG', flags)
+
+
+class FlagConditionsMiddlewareStateTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+        self.middleware = FlagConditionsMiddleware()
+
+    def test_flag_state_uses_cached_request_flags(self):
+        request = self.factory.get('/test')
+        self.middleware.process_request(request)
+        with override_settings(FLAGS={}):
+            self.assertTrue(flag_state('FLAG_ENABLED', request=request))
+
+    def test_flag_state_without_middleware_has_no_cached_request_flags(self):
+        request = self.factory.get('/test')
+        with override_settings(FLAGS={}):
+            self.assertFalse(flag_state('FLAG_ENABLED', request=request))

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -1,12 +1,12 @@
-from django.http import HttpRequest
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
+from flags.settings import Flag
 from flags.state import flag_disabled, flag_enabled, flag_state
 
 
 class FlagStateTestCase(TestCase):
     def setUp(self):
-        self.request = HttpRequest()
+        self.factory = RequestFactory()
 
     def test_non_existent_flag(self):
         """ Non-existent flags always have a default state of False """
@@ -22,8 +22,22 @@ class FlagStateTestCase(TestCase):
 
     def test_flag_state_non_existent_flag_site(self):
         """ Given a site non-existent flags should still be False """
+        request = self.factory.get('/test')
         self.assertFalse(flag_state('FLAG_DOES_NOT_EXIST',
-                                    request=self.request))
+                                    request=request))
+
+    def test_flag_state_request_in_kwargs_with_conditions(self):
+        request = self.factory.get('/test')
+        request.FLAG_CONDITIONS = {
+            'MIDDLEWARE_FLAGGED': Flag(
+                'MIDDLEWARE_FLAGGED', {'boolean': True}
+            )
+        }
+        self.assertTrue(flag_state('MIDDLEWARE_FLAGGED', request=request))
+
+    def test_flag_state_request_in_kwargs_without_conditions(self):
+        request = self.factory.get('/test')
+        self.assertFalse(flag_state('MIDDLEWARE_FLAGGED', request=request))
 
     def test_flag_enabled_enabled(self):
         """ Global flags enabled should be True """

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -1,6 +1,5 @@
 from django.test import RequestFactory, TestCase
 
-from flags.settings import Flag
 from flags.state import flag_disabled, flag_enabled, flag_state
 
 
@@ -25,19 +24,6 @@ class FlagStateTestCase(TestCase):
         request = self.factory.get('/test')
         self.assertFalse(flag_state('FLAG_DOES_NOT_EXIST',
                                     request=request))
-
-    def test_flag_state_request_in_kwargs_with_conditions(self):
-        request = self.factory.get('/test')
-        request.FLAG_CONDITIONS = {
-            'MIDDLEWARE_FLAGGED': Flag(
-                'MIDDLEWARE_FLAGGED', {'boolean': True}
-            )
-        }
-        self.assertTrue(flag_state('MIDDLEWARE_FLAGGED', request=request))
-
-    def test_flag_state_request_in_kwargs_without_conditions(self):
-        request = self.factory.get('/test')
-        self.assertFalse(flag_state('MIDDLEWARE_FLAGGED', request=request))
 
     def test_flag_enabled_enabled(self):
         """ Global flags enabled should be True """

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -8,7 +8,11 @@ class FlagStateTestCase(TestCase):
         self.factory = RequestFactory()
 
     def test_non_existent_flag(self):
-        """ Non-existent flags always have a default state of False """
+        """ Non-existent flags return None """
+        self.assertIsNone(flag_state('FLAG_DOES_NOT_EXIST'))
+
+    def test_non_existent_flag_evaluates_to_false(self):
+        """ Non-existent flags are falsy """
         self.assertFalse(flag_state('FLAG_DOES_NOT_EXIST'))
 
     def test_flag_state_enabled(self):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 long_description = open('README.md', 'r').read()
 
 install_requires = [
-    'Django>=1.8,<2.2',
+    'Django>=1.11,<2.2',
 ]
 
 testing_extras = [
@@ -39,7 +39,6 @@ setup(
     classifiers=[
         'Framework :: Django',
         'Framework :: Django :: 1.11',
-        'Framework :: Django :: 1.8',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{27,36}-dj{18,111},py{36}-dj{20,21}
+envlist=lint,py{27,36}-dj{111},py{36}-dj{20,21}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,7 +16,6 @@ basepython=
     py36: python3.6
 
 deps=
-    dj18: Django>=1.8,<1.9
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2


### PR DESCRIPTION
This should allow us to use the same flag conditions throughout a single request cycle without querying the database more than once per flag. It only affects flag checks that happen during a request cycle and then only when the middleware is enabled and the request is provided as a keyword argument for the flag check (which happens automatically with the context preprocessors configured as the documentation recommends).

This is an alternative, less heavy-handed approach to the same problem that #9 attempts to address. This PR and #9 should be seen as mutually exclusive. 

This change doesn't provide quite as large a performance improvement, and still requires optional configuration to take advantage of (adding the middleware to `MIDDLEWARE`), but it does allow us to start addressing the problem of performance in in checking flags further up the stack. This gives us more flexibility in changing the implementation of how we fetch and handle conditions, which I think I would like to do. I think I prefer this approach.