### PR TITLE
Fix a TypeError when a configured condition has no function registered

### DIFF
--- a/flags/sources.py
+++ b/flags/sources.py
@@ -1,9 +1,13 @@
+import logging
 
 from django.apps import apps
 from django.conf import settings
 from django.utils.module_loading import import_string
 
 from flags.conditions import get_condition
+
+
+logger = logging.getLogger(__name__)
 
 
 class Condition(object):
@@ -14,11 +18,16 @@ class Condition(object):
         self.value = value
         self.fn = get_condition(self.condition)
 
+        if self.fn is None:
+            logger.warning('No condition registered for name '
+                           '"{condition}"'.format(condition=self.condition))
+
     def __eq__(self, other):
         return other.condition == self.condition and other.value == self.value
 
     def check(self, **kwargs):
-        return self.fn(self.value, **kwargs)
+        if self.fn is not None:
+            return self.fn(self.value, **kwargs)
 
 
 class Flag(object):

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -1,7 +1,7 @@
 try:
-    from unittest.mock import Mock
+    from unittest.mock import Mock, patch
 except ImportError:  # pragma: no cover
-    from mock import Mock
+    from mock import Mock, patch
 
 from django.test import TestCase, override_settings
 
@@ -49,6 +49,18 @@ class DatabaseFlagsSourceTestCase(TestCase):
         source = DatabaseFlagsSource()
         flags = source.get_flags()
         self.assertEqual(flags, {'MY_FLAG': [Condition('boolean', 'False'), ]})
+
+
+class ConditionTestCase(TestCase):
+
+    @patch('logging.Logger.warning')
+    def test_check_fn_none(self, mock_warning):
+        condition = Condition('nonexistent', 'value')
+        result = condition.check()
+        mock_warning.assert_called_with(
+            'No condition registered for name "nonexistent"'
+        )
+        self.assertIsNone(result)
 
 
 class FlagTestCase(TestCase):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='4.0.0',
+    version='4.0.1',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
This PR fixes a bug where a TypeError can be raised if a condition function is not registered for a condition name that a flag attempts to check.

Prior to this change the following would raise a TypeError:

```python
condition = Condition('my_condition', 'value')
condition.check()
```

If there is not a corresponding `condition.register('my_condition', fn=my_condition_function)`.

After this change, `condition.check()` will return None, which is Falsy.