### PR TITLE
Move logging of non-existent conditions to a system check

### DIFF
--- a/flags/apps.py
+++ b/flags/apps.py
@@ -1,5 +1,7 @@
 from django.apps import AppConfig
 
+from . import checks  # noqa F401
+
 
 class DjangoFlagsConfig(AppConfig):
     name = 'flags'

--- a/flags/checks.py
+++ b/flags/checks.py
@@ -1,0 +1,29 @@
+from django.core.checks import Warning, register
+
+
+@register()
+def flag_conditions_check(app_configs, **kwargs):
+    from flags.sources import get_flags
+
+    error_str = 'Flag {flag} has non-existent condition "{condition}"'
+    error_hint = 'Register "{condition}" as a Django-Flags condition.'
+
+    errors = []
+
+    flags = get_flags()
+    for name, flag in flags.items():
+        for condition in flag.conditions:
+            if condition.fn is None:
+                errors.append(
+                    Warning(
+                        error_str.format(
+                            flag=name, condition=condition.condition
+                        ),
+                        hint=error_hint.format(
+                            condition=condition.condition
+                        ),
+                        id='flags.E001',
+                    )
+                )
+
+    return errors

--- a/flags/sources.py
+++ b/flags/sources.py
@@ -18,10 +18,6 @@ class Condition(object):
         self.value = value
         self.fn = get_condition(self.condition)
 
-        if self.fn is None:
-            logger.warning('No condition registered for name '
-                           '"{condition}"'.format(condition=self.condition))
-
     def __eq__(self, other):
         return other.condition == self.condition and other.value == self.value
 

--- a/flags/tests/test_checks.py
+++ b/flags/tests/test_checks.py
@@ -1,0 +1,19 @@
+from django.apps import apps
+from django.core.checks import Warning
+from django.test import TestCase, override_settings
+
+from flags.checks import flag_conditions_check
+
+
+class TestFlagsConditionsCheck(TestCase):
+
+    @override_settings(FLAGS={'FLAG_TO_CHECK': {'boolean': True}})
+    def test_check_passes_if_conditions_exist(self):
+        self.assertFalse(flag_conditions_check(apps.get_app_configs()))
+
+    @override_settings(FLAGS={'FLAG_TO_CHECK': {'nonexistent': 'value'}})
+    def test_check_fails_if_conditions_do_not_exist(self):
+        errors = flag_conditions_check(apps.get_app_configs())
+        self.assertEqual(len(errors), 1)
+        self.assertIsInstance(errors[0], Warning)
+        self.assertEqual(errors[0].id, 'flags.E001')

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -1,7 +1,7 @@
 try:
-    from unittest.mock import Mock, patch
+    from unittest.mock import Mock
 except ImportError:  # pragma: no cover
-    from mock import Mock, patch
+    from mock import Mock
 
 from django.test import TestCase, override_settings
 
@@ -53,13 +53,9 @@ class DatabaseFlagsSourceTestCase(TestCase):
 
 class ConditionTestCase(TestCase):
 
-    @patch('logging.Logger.warning')
-    def test_check_fn_none(self, mock_warning):
+    def test_check_fn_none(self):
         condition = Condition('nonexistent', 'value')
         result = condition.check()
-        mock_warning.assert_called_with(
-            'No condition registered for name "nonexistent"'
-        )
         self.assertIsNone(result)
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     license='CC0',
-    version='4.0.1',
+    version='4.0.2',
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,


### PR DESCRIPTION
This PR moves the logging introduced in #15 to a system check at startup time.

This looks like:

```
Performing system checks...

System check identified some issues:

WARNINGS:
?: (flags.E001) Flag TEST_FLAG has non-existent condition "site"
	HINT: Register "site" as a Django-Flags condition.

System check identified 1 issue (0 silenced).
```