### PR TITLE
fix for failing migrate

### DIFF
--- a/flags/checks.py
+++ b/flags/checks.py
@@ -1,4 +1,5 @@
 from django.core.checks import Warning, register
+from django.db import ProgrammingError
 
 
 @register()
@@ -10,7 +11,13 @@ def flag_conditions_check(app_configs, **kwargs):
 
     errors = []
 
-    flags = get_flags()
+    # fetch flags, fail gracefully when the initial migration has
+    # not yet been applied
+    try:
+        flags = get_flags()
+    except ProgrammingError:
+        return []
+
     for name, flag in flags.items():
         for condition in flag.conditions:
             if condition.fn is None:


### PR DESCRIPTION
the initial migration for django-flags would fail as I followed the installation instructions because there is code that runs prior to the migration being completed that depends on a proper migration having already occurred.  This PR catches the failure and allows the process to complete.