### PR TITLE
Optionally catch exceptions in flag sources

### DIFF
--- a/docs/api/sources.md
+++ b/docs/api/sources.md
@@ -19,9 +19,9 @@ class CustomFlagSource(object):
 
 ## API
 
-### `get_flags(sources=None)`
+### `get_flags(sources=None, ignore_errors=False)`
 
-Return a dictionary of all flag names with [`Flag`](#flagname-conditions) objects that are available in the given `sources`. If `sources` is not given, the sources in the [`FLAG_SOURCES` setting](../settings/#flag_sources) are used.
+Return a dictionary of all flag names with [`Flag`](#flagname-conditions) objects that are available in the given `sources`. If `sources` is not given, the sources in the [`FLAG_SOURCES` setting](../settings/#flag_sources) are used. If `ignore_errors` is `True`, any exceptions that occur when getting flags from a source will be caught and ignored.
 
 ### `Condition(condition, value, source=None, obj=None)`
 

--- a/flags/checks.py
+++ b/flags/checks.py
@@ -10,7 +10,7 @@ def flag_conditions_check(app_configs, **kwargs):
 
     errors = []
 
-    flags = get_flags()
+    flags = get_flags(ignore_errors=True)
     for name, flag in flags.items():
         for condition in flag.conditions:
             if condition.fn is None:

--- a/flags/sources.py
+++ b/flags/sources.py
@@ -80,11 +80,10 @@ class DatabaseFlagsSource(object):
             flags[o.name].append(DatabaseCondition(
                 o.condition, o.value, obj=o
             ))
-
         return flags
 
 
-def get_flags(sources=None):
+def get_flags(sources=None, ignore_errors=False):
     """ Get all flag sources sources defined in settings.FLAG_SOURCES.
     FLAG_SOURCES is expected to be a list of Python paths to classes providing
     a get_flags() method that returns a dict with the same format as the
@@ -100,7 +99,14 @@ def get_flags(sources=None):
     for source_str in sources:
         source_cls = import_string(source_str)
         source_obj = source_cls()
-        source_flags = source_obj.get_flags()
+
+        try:
+            source_flags = source_obj.get_flags()
+        except Exception:
+            if ignore_errors:
+                continue
+            else:
+                raise
 
         for flag, conditions in source_flags.items():
             if flag in flags:

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -26,6 +26,11 @@ class TestFlagsSource(object):
         }
 
 
+class ExceptionalFlagsSource(object):
+    def get_flags(self):
+        raise Exception('This flag source is exceptional!')
+
+
 class SettingsFlagsSourceTestCase(TestCase):
 
     @override_settings(FLAGS={'MY_FLAG': {'boolean': True}})
@@ -112,3 +117,17 @@ class GetFlagsTestCase(TestCase):
         self.assertIn('SOURCED_FLAG', flags)
         self.assertEqual(len(flags['OTHER_FLAG'].conditions), 0)
         self.assertEqual(len(flags['SOURCED_FLAG'].conditions), 1)
+
+    def test_ignore_errors(self):
+        # Without ignore_errors
+        with self.assertRaises(Exception):
+            get_flags(
+                sources=['flags.tests.test_sources.ExceptionalFlagsSource', ]
+            )
+
+        # With ignore_errors
+        flags = get_flags(
+            sources=['flags.tests.test_sources.ExceptionalFlagsSource', ],
+            ignore_errors=True
+        )
+        self.assertEqual(flags, {})


### PR DESCRIPTION
This change adds an option to `get_flags` to ignore any errors that occur when getting flags from a flag source. The `ignore_errors` option is `False` by default.

This allows the `DatabaseFlagsSource` to raise an `OperationalError` or `ProgrammingError` when running the system check before migrations have been applied without causing any issues.

`ignore_errors` is now used in the flag conditions system check so the check won't error when migrations have not yet been run.

Fixes #18 and closes #17.