### PR TITLE
Add a boolean AND condition and a "before date" condition

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -56,6 +56,14 @@ Allows a flag to be enabled after a given date (and time) given in [ISO 8601 for
 FLAGS = {'MY_FLAG': {'after date': '2017-06-01T12:00Z'}}
 ```
 
+### `before_date`
+
+Allows a flag to be enabled before a given date (and time) given in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601). The time must be specified either in UTC or as an offset from UTC.
+
+```python
+FLAGS = {'MY_FLAG': {'before date': '2022-06-01T12:00Z'}}
+```
+
 ### `and`
 
 Allows a flag to be enabled only when a set of conditions are all true. 

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -12,6 +12,8 @@ A simple boolean true/false intended to enable or disable a flag explicitly. The
 FLAGS = {'MY_FLAG': {'boolean': True}}
 ```
 
+The value can be given as a Python `True` or `False` object or as the strings `"true"`, `"True"`, `"False"`, or `"false"`.
+
 ### `user`
 
 Allows a flag to be enabled for the username given as the condition's value.
@@ -27,6 +29,8 @@ Allows a flag to be either enabled or disabled depending on the condition's bool
 ```python
 FLAGS = {'MY_FLAG': {'anonymous': False}}
 ```
+
+The value can be given as a Python `True` or `False` object or as the strings `"true"`, `"True"`, `"False"`, or `"false"`.
 
 ### `parameter`
 
@@ -50,6 +54,26 @@ Allows a flag to be enabled after a given date (and time) given in [ISO 8601 for
 
 ```python
 FLAGS = {'MY_FLAG': {'after date': '2017-06-01T12:00Z'}}
+```
+
+### `and`
+
+Allows a flag to be enabled only when a set of conditions are all true. 
+
+```python
+FLAGS = {'MY_FLAG': {
+    'and': [
+        ('path', '/flagged/path'), 
+        ('after date', '2017-06-01T12:00Z')
+    ]
+}}
+```
+
+The value can also be given as a string with comma-separated pairs of conditions, one pair per line:
+
+```
+path, /flagged/path
+after date, 2017-06-01T12:00Z
 ```
 
 ## Custom conditions

--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -92,7 +92,7 @@ def anonymous_condition(boolean_value, request=None, **kwargs):
 
 @register('parameter')
 def parameter_condition(param_name, request=None, **kwargs):
-    """ is the parameter name part of the GET parameters? """
+    """ Is the parameter name part of the GET parameters? """
     if request is None:
         raise RequiredForCondition("request is required for condition "
                                    "'parameter'")
@@ -111,8 +111,8 @@ def path_condition(pattern, request=None, **kwargs):
 
 
 @register('after date')
-def date_condition(date_or_str, **kwargs):
-    """ Does the current date match the given date?
+def after_date_condition(date_or_str, **kwargs):
+    """ Is the the current date after the given date?
     date_or_str is either a date object or an ISO 8601 string """
     try:
         date = dateparse.parse_datetime(date_or_str)
@@ -123,6 +123,30 @@ def date_condition(date_or_str, **kwargs):
 
     try:
         date_test = (now >= date)
+    except TypeError:
+        date_test = False
+
+    return date_test
+
+
+# Keeping the old name of this condition function around for
+# backwards-compatibility.
+date_condition = after_date_condition
+
+
+@register('before date')
+def before_date_condition(date_or_str, **kwargs):
+    """ Is the current date before the given date?
+    date_or_str is either a date object or an ISO 8601 string """
+    try:
+        date = dateparse.parse_datetime(date_or_str)
+    except TypeError:
+        date = date_or_str
+
+    now = timezone.now()
+
+    try:
+        date_test = (now <= date)
     except TypeError:
         date_test = False
 

--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -1,3 +1,4 @@
+import csv
 import re
 
 import django
@@ -126,3 +127,20 @@ def date_condition(date_or_str, **kwargs):
         date_test = False
 
     return date_test
+
+
+@register('and')
+def and_condition(conditions_list, **kwargs):
+    """ Are multiple conditions all True?,
+    conditions_list is in the format [('condition', value), ...] or as
+    comma-seprated 'condition, value' strings with one pair per line. """
+    try:
+        conditions_list = csv.reader(conditions_list.split())
+    except AttributeError:
+        pass
+
+    conditions = ((get_condition(c), v) for c, v in conditions_list)
+    return all(
+        fn(v, **kwargs) if fn is not None else False
+        for fn, v in conditions
+    )

--- a/flags/forms.py
+++ b/flags/forms.py
@@ -7,13 +7,22 @@ from flags.sources import get_flags
 
 class FlagStateForm(forms.ModelForm):
     name = forms.ChoiceField(
-        label="Flag", required=True
+        label="Flag",
+        required=True
     )
     condition = forms.ChoiceField(
-        label="Is enabled when", required=True
+        label="Is enabled when",
+        required=True
     )
     value = forms.CharField(
-        label="Is", required=True, widget=forms.Textarea
+        label="Is",
+        required=True,
+        widget=forms.Textarea(
+            attrs={
+                'rows': 2,
+                'cols': 40,
+            }
+        )
     )
 
     def __init__(self, *args, **kwargs):

--- a/flags/forms.py
+++ b/flags/forms.py
@@ -13,7 +13,7 @@ class FlagStateForm(forms.ModelForm):
         label="Is enabled when", required=True
     )
     value = forms.CharField(
-        label="Is", required=True
+        label="Is", required=True, widget=forms.Textarea
     )
 
     def __init__(self, *args, **kwargs):

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -9,6 +9,7 @@ from flags.conditions import (
     CONDITIONS,
     DuplicateCondition,
     RequiredForCondition,
+    and_condition,
     anonymous_condition,
     boolean_condition,
     date_condition,
@@ -212,3 +213,32 @@ class DateConditionTestCase(TestCase):
 
     def test_not_valid_date_str(self):
         self.assertFalse(date_condition('I am not a valid date'))
+
+
+class AndConditionTestCase(TestCase):
+
+    def test_and_condition_true(self):
+        self.assertTrue(and_condition(
+            [('boolean', True), ('boolean', True)]
+        ))
+
+    def test_and_condition_false(self):
+        self.assertFalse(and_condition(
+            [('boolean', False), ('boolean', False)]
+        ))
+        self.assertFalse(and_condition(
+            [('boolean', False), ('boolean', True)]
+        ))
+
+    def test_and_condition_sub_condition_dne(self):
+        self.assertFalse(and_condition(
+            [('boolean', True), ('blorp', True)]
+        ))
+
+    def test_parse_csv(self):
+        self.assertTrue(and_condition(
+            '''
+            boolean,True
+            boolean,True
+            '''
+        ))

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -9,10 +9,11 @@ from flags.conditions import (
     CONDITIONS,
     DuplicateCondition,
     RequiredForCondition,
+    after_date_condition,
     and_condition,
     anonymous_condition,
+    before_date_condition,
     boolean_condition,
-    date_condition,
     get_condition,
     parameter_condition,
     path_condition,
@@ -170,7 +171,7 @@ class PathConditionTestCase(TestCase):
             path_condition('/my/path')
 
 
-class DateConditionTestCase(TestCase):
+class AfterDateConditionTestCase(TestCase):
 
     def setUp(self):
         # Set up some datetimes relative to now for testing
@@ -188,31 +189,76 @@ class DateConditionTestCase(TestCase):
         self.future_datetime_notz_str = self.future_datetime_notz.isoformat()
 
     def test_date_timeone_true(self):
-        self.assertTrue(date_condition(self.past_datetime_tz))
+        self.assertTrue(after_date_condition(self.past_datetime_tz))
 
     def test_date_no_timeone_true(self):
-        self.assertTrue(date_condition(self.past_datetime_notz))
+        self.assertTrue(after_date_condition(self.past_datetime_notz))
 
     def test_date_str_timeone_true(self):
-        self.assertTrue(date_condition(self.past_datetime_tz_str))
+        self.assertTrue(after_date_condition(self.past_datetime_tz_str))
 
     def test_date_str_no_timeone_true(self):
-        self.assertTrue(date_condition(self.past_datetime_notz_str))
+        self.assertTrue(after_date_condition(self.past_datetime_notz_str))
 
     def test_date_timeone_false(self):
-        self.assertFalse(date_condition(self.future_datetime_tz))
+        self.assertFalse(after_date_condition(self.future_datetime_tz))
 
     def test_date_no_timeone_false(self):
-        self.assertFalse(date_condition(self.future_datetime_notz))
+        self.assertFalse(after_date_condition(self.future_datetime_notz))
 
     def test_date_str_timeone_false(self):
-        self.assertFalse(date_condition(self.future_datetime_tz_str))
+        self.assertFalse(after_date_condition(self.future_datetime_tz_str))
 
     def test_date_str_no_timeone_false(self):
-        self.assertFalse(date_condition(self.future_datetime_notz_str))
+        self.assertFalse(after_date_condition(self.future_datetime_notz_str))
 
     def test_not_valid_date_str(self):
-        self.assertFalse(date_condition('I am not a valid date'))
+        self.assertFalse(after_date_condition('I am not a valid date'))
+
+
+class BeforeDateConditionTestCase(TestCase):
+
+    def setUp(self):
+        # Set up some datetimes relative to now for testing
+        delta = timedelta(days=1)
+
+        self.past_datetime_tz = timezone.now() - delta
+        self.past_datetime_notz = self.past_datetime_tz.replace(tzinfo=None)
+        self.past_datetime_tz_str = self.past_datetime_tz.isoformat()
+        self.past_datetime_notz_str = self.past_datetime_notz.isoformat()
+
+        self.future_datetime_tz = timezone.now() + delta
+        self.future_datetime_notz = self.future_datetime_tz.replace(
+            tzinfo=None)
+        self.future_datetime_tz_str = self.future_datetime_tz.isoformat()
+        self.future_datetime_notz_str = self.future_datetime_notz.isoformat()
+
+    def test_date_timeone_true(self):
+        self.assertTrue(before_date_condition(self.future_datetime_tz))
+
+    def test_date_no_timeone_true(self):
+        self.assertTrue(before_date_condition(self.future_datetime_notz))
+
+    def test_date_str_timeone_true(self):
+        self.assertTrue(before_date_condition(self.future_datetime_tz_str))
+
+    def test_date_str_no_timeone_true(self):
+        self.assertTrue(before_date_condition(self.future_datetime_notz_str))
+
+    def test_date_timeone_false(self):
+        self.assertFalse(before_date_condition(self.past_datetime_tz))
+
+    def test_date_no_timeone_false(self):
+        self.assertFalse(before_date_condition(self.past_datetime_notz))
+
+    def test_date_str_timeone_false(self):
+        self.assertFalse(before_date_condition(self.past_datetime_tz_str))
+
+    def test_date_str_no_timeone_false(self):
+        self.assertFalse(before_date_condition(self.past_datetime_notz_str))
+
+    def test_not_valid_date_str(self):
+        self.assertFalse(before_date_condition('I am not a valid date'))
 
 
 class AndConditionTestCase(TestCase):


### PR DESCRIPTION
This PR adds two new conditions:

- `before date` simply enables a flag if the current date is *before* the given date. This is the inverse of the existing `after date` condition.
- `and` performs a boolean AND on a list of conditions (the Django-Flags default is an OR), which means *all* the conditions in the `and` value must evaluate to `True` before the flag will be enabled.

The `and` condition, if given in Python code (i.e. with the Django settings flag source) takes a list of two-tuples containing `('condition name', expected_value)`. If given as a string (i.e. in the Django admin using the database flag source) it can contain a string with comma-separated pairs with one condition, value pair per line. 

Per the documentation:


```python
FLAGS = {'MY_FLAG': {
    'and': [
        ('path', '/flagged/path'), 
        ('after date', '2017-06-01T12:00Z')
    ]
}}
```

And:

```
path, /flagged/path
after date, 2017-06-01T12:00Z
```

To facilitate the multi-line strings (and any other possible custom conditions that users of Django-Flags might create, this PR also changes the database flag state form's widget to a text area instead of an input box. This makes `and` conditions possible to create in the UI, but it's still a bit clunky.