### PR TITLE
Update RTD MkDocs theme overrides from cfgov-refresh

### DIFF
--- a/docs/css/overrides.css
+++ b/docs/css/overrides.css
@@ -1,57 +1,188 @@
-a, 
+a,
 .rst-content a code {
-    color: #0072ce;
+    color: #0072ce; /* Pacific */
+    text-decoration: underline;
 }
+
 a:visited,
 .rst-content a:visited code {
-    color: #a01b68;
+    color: #0072ce; /* Pacific */
 }
+
 a:hover,
+a:focus,
 .rst-content a:hover code {
-    color: #0050b4;
+    color: #0050b4; /* Dark Pacific */
 }
+
+a:active {
+    color: #254b87; /* Navy */
+}
+
+nav a,
+a.btn {
+    text-decoration: none;
+}
+
 .wy-body-for-nav {
-    background-color: #ffffff;
+    background-color: #fff;
 }
+
 .wy-nav-top {
-    background: #1e9642;
+    background: #1e9642; /* Dark Green */
 }
+
 .wy-nav-top a,
 .wy-nav-top a:visited {
-    color: #ffffff;
+    color: #fff;
 }
+
 .wy-side-nav-search {
-    background-color: #1e9642;
+    background-color: #1e9642; /* Dark Green */
 }
-.wy-side-nav-search > a, 
+
+.wy-side-nav-search > a,
 .wy-side-nav-search .wy-dropdown > a {
-    color: #ffffff;
+    color: #fff;
     font-size: 150%;
 }
+
 .wy-side-nav-search input[type=text] {
-    border-color: #1e9642;
+    border-color: #1e9642; /* Dark Green */
 }
+
 .wy-menu-vertical .caption-text {
-    color: #ffffff;
+    color: #d2d3d5; /* Gray 20 */
 }
+
 .wy-menu-vertical li.current .subnav a,
 .wy-menu-vertical .subnav li.current a {
-    color: #101820;
+    color: #101820; /* CFPB Black */
 }
+
 .wy-nav-side {
-    background: #43484e;
+    background: #43484e; /* Dark Gray */
 }
+
 .wy-menu-vertical li a,
 .wy-menu-vertical .subnav li a {
-    color: #ffffff;
+    color: #fff;
 }
+
 .wy-menu-vertical li a:hover {
-    background-color: #5a5d61
+    background-color: #5a5d61; /* Gray */
 }
+
 .rst-versions .rst-current-version {
-    background-color: #43484e;
+    background-color: #43484e; /* Dark Gray */
 }
+
+.rst-content .section ol ol {
+    margin-bottom: 0;
+}
+
+.rst-content tt,
+.rst-content code {
+    font-family: SFMono-Regular,
+    Menlo,
+    Monaco, Consolas, "Liberation Mono", "Courier New", Courier, monospace;
+}
+
+.rst-content pre.literal-block,
+.rst-content div[class^="highlight"] pre,
+.rst-content .linenodiv pre,
+pre.highlight {
+    line-height: 1.4;
+}
+
+p code,
+.admonition code {
+    background-color: #fff;
+    color: #d14124; /* Red */
+}
+
+.wy-alert.wy-alert-info,
+.rst-content .note,
+.rst-content .wy-alert-info.attention,
+.rst-content .wy-alert-info.caution,
+.rst-content .wy-alert-info.danger,
+.rst-content .wy-alert-info.error,
+.rst-content .wy-alert-info.hint,
+.rst-content .wy-alert-info.important,
+.rst-content .wy-alert-info.tip,
+.rst-content .wy-alert-info.warning,
+.rst-content .seealso,
+.rst-content .wy-alert-info.admonition-todo {
+    background-color: #f4f6fa; /* Navy 10 */
+}
+
+.wy-alert.wy-alert-info .wy-alert-title,
+.rst-content .note .wy-alert-title,
+.rst-content .wy-alert-info.attention .wy-alert-title,
+.rst-content .wy-alert-info.caution .wy-alert-title,
+.rst-content .wy-alert-info.danger .wy-alert-title,
+.rst-content .wy-alert-info.error .wy-alert-title,
+.rst-content .wy-alert-info.hint .wy-alert-title,
+.rst-content .wy-alert-info.important .wy-alert-title,
+.rst-content .wy-alert-info.tip .wy-alert-title,
+.rst-content .wy-alert-info.warning .wy-alert-title,
+.rst-content .seealso .wy-alert-title,
+.rst-content .wy-alert-info.admonition-todo .wy-alert-title,
+.wy-alert.wy-alert-info .rst-content .admonition-title,
+.rst-content .wy-alert.wy-alert-info .admonition-title,
+.rst-content .note .admonition-title,
+.rst-content .wy-alert-info.attention .admonition-title,
+.rst-content .wy-alert-info.caution .admonition-title,
+.rst-content .wy-alert-info.danger .admonition-title,
+.rst-content .wy-alert-info.error .admonition-title,
+.rst-content .wy-alert-info.hint .admonition-title,
+.rst-content .wy-alert-info.important .admonition-title,
+.rst-content .wy-alert-info.tip .admonition-title,
+.rst-content .wy-alert-info.warning .admonition-title,
+.rst-content .seealso .admonition-title,
+.rst-content .wy-alert-info.admonition-todo .admonition-title {
+    background: #5674a3; /* Navy 80 */
+}
+
+.hljs {
+    background-color: #f7f8f9; /* Gray 5 */
+    color: #101820; /* CFPB Black */
+}
+
+.hljs-comment,
+.hljs-quote {
+    color: #5a5d61; /* Gray */
+}
+
+.hljs-meta {
+    color: #43484e; /* Dark Gray */
+}
+
+.hljs-keyword,
+.hljs-selector-tag,
+.hljs-subst {
+    color: #005e5d; /* Dark Teal */
+}
+
+.hljs-type,
+.hljs-class .hljs-title,
+.hljs-tag,
+.hljs-name,
+.hljs-attribute {
+    color: #0050B4; /* Dark Pacific */
+}
+
+.hljs-title,
+.hljs-section,
+.hljs-selector-id {
+    color: #002d72; /* Dark Navy */
+}
+
+.hljs-string,
+.hljs-doctag {
+    color: #b4267a; /* Purple */
+}
+
 footer {
-    color: #5a5d61;
-}
+    color: #5a5d61; /* Gray */
 }

--- a/docs/theme-overrides/toc.html
+++ b/docs/theme-overrides/toc.html
@@ -1,0 +1,9 @@
+{% for toc_item in page.toc %}
+    {% if toc_item.children %}
+        <ul>
+        {% for toc_item in toc_item.children %}
+            <li><a class="toctree-l{{ navlevel + 2 }}" href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+        {% endfor %}
+        </ul>
+    {% endif %}
+{% endfor %}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,6 +16,7 @@ pages:
     - Release notes: releasenotes.md
 theme:
   name: 'readthedocs'
+  custom_dir: docs/theme-overrides/
 extra_css:
     - css/overrides.css
 markdown_extensions:


### PR DESCRIPTION
This PR updates the overrides for the MkDocs ReadTheDocs theme from the [cfpb/cfgov-refresh docs](https://github.com/cfpb/cfgov-refresh/tree/master/docs).