### PR TITLE
Add a "before date" condition

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -12,6 +12,8 @@ A simple boolean true/false intended to enable or disable a flag explicitly. The
 FLAGS = {'MY_FLAG': {'boolean': True}}
 ```
 
+The value can be given as a Python `True` or `False` Boolean value or as the strings `"true"`, `"True"`, `"False"`, or `"false"`.
+
 ### `user`
 
 Allows a flag to be enabled for the username given as the condition's value.
@@ -27,6 +29,8 @@ Allows a flag to be either enabled or disabled depending on the condition's bool
 ```python
 FLAGS = {'MY_FLAG': {'anonymous': False}}
 ```
+
+The value can be given as a Python `True` or `False` Boolean value or as the strings `"true"`, `"True"`, `"False"`, or `"false"`.
 
 ### `parameter`
 
@@ -50,6 +54,14 @@ Allows a flag to be enabled after a given date (and time) given in [ISO 8601 for
 
 ```python
 FLAGS = {'MY_FLAG': {'after date': '2017-06-01T12:00Z'}}
+```
+
+### `before_date`
+
+Allows a flag to be enabled before a given date (and time) given in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601). The time must be specified either in UTC or as an offset from UTC.
+
+```python
+FLAGS = {'MY_FLAG': {'before date': '2022-06-01T12:00Z'}}
 ```
 
 ## Custom conditions

--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -91,7 +91,7 @@ def anonymous_condition(boolean_value, request=None, **kwargs):
 
 @register('parameter')
 def parameter_condition(param_name, request=None, **kwargs):
-    """ is the parameter name part of the GET parameters? """
+    """ Is the parameter name part of the GET parameters? """
     if request is None:
         raise RequiredForCondition("request is required for condition "
                                    "'parameter'")
@@ -110,8 +110,8 @@ def path_condition(pattern, request=None, **kwargs):
 
 
 @register('after date')
-def date_condition(date_or_str, **kwargs):
-    """ Does the current date match the given date?
+def after_date_condition(date_or_str, **kwargs):
+    """ Is the the current date after the given date?
     date_or_str is either a date object or an ISO 8601 string """
     try:
         date = dateparse.parse_datetime(date_or_str)
@@ -121,7 +121,31 @@ def date_condition(date_or_str, **kwargs):
     now = timezone.now()
 
     try:
-        date_test = (now >= date)
+        date_test = (now > date)
+    except TypeError:
+        date_test = False
+
+    return date_test
+
+
+# Keeping the old name of this condition function around for
+# backwards-compatibility.
+date_condition = after_date_condition
+
+
+@register('before date')
+def before_date_condition(date_or_str, **kwargs):
+    """ Is the current date before the given date?
+    date_or_str is either a date object or an ISO 8601 string """
+    try:
+        date = dateparse.parse_datetime(date_or_str)
+    except TypeError:
+        date = date_or_str
+
+    now = timezone.now()
+
+    try:
+        date_test = (now < date)
     except TypeError:
         date_test = False
 

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -9,9 +9,10 @@ from flags.conditions import (
     CONDITIONS,
     DuplicateCondition,
     RequiredForCondition,
+    after_date_condition,
     anonymous_condition,
+    before_date_condition,
     boolean_condition,
-    date_condition,
     get_condition,
     parameter_condition,
     path_condition,
@@ -169,7 +170,7 @@ class PathConditionTestCase(TestCase):
             path_condition('/my/path')
 
 
-class DateConditionTestCase(TestCase):
+class AfterDateConditionTestCase(TestCase):
 
     def setUp(self):
         # Set up some datetimes relative to now for testing
@@ -187,28 +188,73 @@ class DateConditionTestCase(TestCase):
         self.future_datetime_notz_str = self.future_datetime_notz.isoformat()
 
     def test_date_timeone_true(self):
-        self.assertTrue(date_condition(self.past_datetime_tz))
+        self.assertTrue(after_date_condition(self.past_datetime_tz))
 
     def test_date_no_timeone_true(self):
-        self.assertTrue(date_condition(self.past_datetime_notz))
+        self.assertTrue(after_date_condition(self.past_datetime_notz))
 
     def test_date_str_timeone_true(self):
-        self.assertTrue(date_condition(self.past_datetime_tz_str))
+        self.assertTrue(after_date_condition(self.past_datetime_tz_str))
 
     def test_date_str_no_timeone_true(self):
-        self.assertTrue(date_condition(self.past_datetime_notz_str))
+        self.assertTrue(after_date_condition(self.past_datetime_notz_str))
 
     def test_date_timeone_false(self):
-        self.assertFalse(date_condition(self.future_datetime_tz))
+        self.assertFalse(after_date_condition(self.future_datetime_tz))
 
     def test_date_no_timeone_false(self):
-        self.assertFalse(date_condition(self.future_datetime_notz))
+        self.assertFalse(after_date_condition(self.future_datetime_notz))
 
     def test_date_str_timeone_false(self):
-        self.assertFalse(date_condition(self.future_datetime_tz_str))
+        self.assertFalse(after_date_condition(self.future_datetime_tz_str))
 
     def test_date_str_no_timeone_false(self):
-        self.assertFalse(date_condition(self.future_datetime_notz_str))
+        self.assertFalse(after_date_condition(self.future_datetime_notz_str))
 
     def test_not_valid_date_str(self):
-        self.assertFalse(date_condition('I am not a valid date'))
+        self.assertFalse(after_date_condition('I am not a valid date'))
+
+
+class BeforeDateConditionTestCase(TestCase):
+
+    def setUp(self):
+        # Set up some datetimes relative to now for testing
+        delta = timedelta(days=1)
+
+        self.past_datetime_tz = timezone.now() - delta
+        self.past_datetime_notz = self.past_datetime_tz.replace(tzinfo=None)
+        self.past_datetime_tz_str = self.past_datetime_tz.isoformat()
+        self.past_datetime_notz_str = self.past_datetime_notz.isoformat()
+
+        self.future_datetime_tz = timezone.now() + delta
+        self.future_datetime_notz = self.future_datetime_tz.replace(
+            tzinfo=None)
+        self.future_datetime_tz_str = self.future_datetime_tz.isoformat()
+        self.future_datetime_notz_str = self.future_datetime_notz.isoformat()
+
+    def test_date_timeone_true(self):
+        self.assertTrue(before_date_condition(self.future_datetime_tz))
+
+    def test_date_no_timeone_true(self):
+        self.assertTrue(before_date_condition(self.future_datetime_notz))
+
+    def test_date_str_timeone_true(self):
+        self.assertTrue(before_date_condition(self.future_datetime_tz_str))
+
+    def test_date_str_no_timeone_true(self):
+        self.assertTrue(before_date_condition(self.future_datetime_notz_str))
+
+    def test_date_timeone_false(self):
+        self.assertFalse(before_date_condition(self.past_datetime_tz))
+
+    def test_date_no_timeone_false(self):
+        self.assertFalse(before_date_condition(self.past_datetime_notz))
+
+    def test_date_str_timeone_false(self):
+        self.assertFalse(before_date_condition(self.past_datetime_tz_str))
+
+    def test_date_str_no_timeone_false(self):
+        self.assertFalse(before_date_condition(self.past_datetime_notz_str))
+
+    def test_not_valid_date_str(self):
+        self.assertFalse(before_date_condition('I am not a valid date'))


### PR DESCRIPTION
This PR adds a new `before date` condition that simply enables a flag if the current date is *before* the given date. This is the inverse of the existing `after date` condition.