### PR TITLE
Permit empty values for conditions

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -56,4 +56,6 @@ FLAGS = {
 }
 ```
 
+A condition's value can be None, or not given in the condition dictionary, and the condition will not never be met.
+
 Previously flag definitions in `FLAGS` supported a single dictionary (rather than a list) with the condition name as the key and expected value as value. This method of specifying flags is deprecated and will be removed in Django-Flags 5.0.

--- a/flags/sources.py
+++ b/flags/sources.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 class Condition(object):
     """ A simple wrapper around conditions """
 
-    def __init__(self, condition, value, required=False):
+    def __init__(self, condition, value=None, required=False):
         self.condition = condition
         self.value = value
         self.fn = get_condition(self.condition)
@@ -24,7 +24,7 @@ class Condition(object):
         return other.condition == self.condition and other.value == self.value
 
     def check(self, **kwargs):
-        if self.fn is not None:
+        if self.fn is not None and self.value is not None:
             return self.fn(self.value, **kwargs)
 
 
@@ -83,17 +83,17 @@ class SettingsFlagsSource(object):
                 if isinstance(c, dict):
                     condition = Condition(
                         c['condition'],
-                        c['value'],
+                        value=c.get('value'),
                         required=c.get('required', False)
                     )
 
                 # (condition, value, required)
                 elif len(c) == 3:
-                    condition = Condition(c[0], c[1], required=c[2])
+                    condition = Condition(c[0], value=c[1], required=c[2])
 
                 # (condition, value)
                 else:
-                    condition = Condition(c[0], c[1], required=False)
+                    condition = Condition(c[0], value=c[1], required=False)
 
                 flags[flag].append(condition)
 
@@ -122,7 +122,7 @@ class DatabaseFlagsSource(object):
             if o.name not in flags:
                 flags[o.name] = []
             flags[o.name].append(DatabaseCondition(
-                o.condition, o.value, required=o.required, obj=o
+                o.condition, value=o.value, required=o.required, obj=o
             ))
         return flags
 

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -162,6 +162,10 @@ class FlagTestCase(TestCase):
         ])
         self.assertFalse(flag.check_state(request=request))
 
+    def test_check_state_empty_value(self):
+        flag = Flag('MY_FLAG', [Condition('boolean')])
+        self.assertFalse(flag.check_state())
+
 
 class GetFlagsTestCase(TestCase):
 


### PR DESCRIPTION
This PR makes it possible to define conditions that do not have a value, or have `None` as their value. If the value is not given or is `None` the condition will never be met.