### PR TITLE
Fix boolean and parameter conditions

### DIFF
--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -34,10 +34,16 @@ The value can be given as a Python `True` or `False` Boolean value or as the str
 
 ### `parameter`
 
-Allows a flag to be enabled if a GET parameter with the condition's value as its name exists for a request.
+Allows a flag to be enabled by including a parameter in the request's query string. `value` is the name of the parameter, or a name and expected value. If an expected value isn't provided, the value must by `true`.
 
 ```python
-FLAGS = {'MY_FLAG': [{'condition': 'parameter', 'value': 'my_flag_param'}]}
+FLAGS = {
+    'MY_FLAG': [
+        {'condition': 'parameter', 'value': 'my_flag_param1'},      # ?my_flag_param1=true
+        {'condition': 'parameter', 'value': 'my_flag_param2=now'},  # ?my_flag_param2=now
+        {'condition': 'parameter', 'value': 'my_flag_param3='},     # ?my_flag_param3
+    ]
+}
 ```
 
 ### `path matches`

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -6,13 +6,14 @@ Django-Flags comes with the following conditions built-in:
 
 ### `boolean`
 
-A simple boolean true/false intended to enable or disable a flag explicitly. The state of the flag evaluates to the value of the boolean condition.
+A simple boolean true/false intended to enable or disable a flag explicitly. The state of the flag evaluates to the value of the boolean condition. 
+
 
 ```python
 FLAGS = {'MY_FLAG': [{'condition': 'boolean', 'value': True}]}
 ```
 
-The value can be given as a Python `True` or `False` Boolean value or as the strings `"true"`, `"True"`, `"False"`, or `"false"`.
+The value can given as a Python `True` or `False` or  as any [string representation of truth](https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool), such as `y`, `yes`, `t`, `true`, `on` and `1` for true values, and `n`, `no`, `f`, `false`, `off` and `0` for false values.
 
 ### `user`
 
@@ -30,7 +31,7 @@ Allows a flag to be either enabled or disabled depending on the condition's bool
 FLAGS = {'MY_FLAG': [{'condition': 'anonymous', 'value': False}]}
 ```
 
-The value can be given as a Python `True` or `False` Boolean value or as the strings `"true"`, `"True"`, `"False"`, or `"false"`.
+The value can given as a Python `True` or `False` or  as any [string representation of truth](https://docs.python.org/3/distutils/apiref.html#distutils.util.strtobool), such as `y`, `yes`, `t`, `true`, `on` and `1` for true values, and `n`, `no`, `f`, `false`, `off` and `0` for false values.
 
 ### `parameter`
 

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -34,7 +34,7 @@ The value can be given as a Python `True` or `False` Boolean value or as the str
 
 ### `parameter`
 
-Allows a flag to be enabled based on a GET parameter with the name given as the condition's value.
+Allows a flag to be enabled if a GET parameter with the condition's value as its name exists for a request.
 
 ```python
 FLAGS = {'MY_FLAG': [{'condition': 'parameter', 'value': 'my_flag_param'}]}

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -35,7 +35,7 @@ The value can given as a Python `True` or `False` or  as any [string representat
 
 ### `parameter`
 
-Allows a flag to be enabled by including a parameter in the request's query string. `value` is the name of the parameter, or a name and expected value. If an expected value isn't provided, the value must by `true`.
+Allows a flag to be enabled by including a parameter in the request's query string. `value` is the name of the parameter, or a name and expected value. If an expected value isn't provided, the value must be `True`.
 
 ```python
 FLAGS = {

--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -83,9 +83,14 @@ def anonymous_condition(boolean_value, request=None, **kwargs):
                                    "'anonymous'")
 
     if django.VERSION[0] >= 2:  # pragma: no cover
-        return bool(boolean_value) == bool(request.user.is_anonymous)
+        is_anonymous = bool(request.user.is_anonymous)
     else:  # pragma: no cover
-        return bool(boolean_value) == bool(request.user.is_anonymous())
+        is_anonymous = bool(request.user.is_anonymous())
+
+    try:
+        return strtobool(boolean_value.strip().lower()) == is_anonymous
+    except AttributeError:
+        return bool(boolean_value) == is_anonymous
 
 
 @register('parameter')

--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -1,4 +1,5 @@
 import re
+from distutils.util import strtobool
 
 import django
 from django.utils import dateparse, timezone
@@ -58,9 +59,7 @@ def get_condition(condition_name):
 def boolean_condition(condition, **kwargs):
     """ Basic boolean check """
     try:
-        if condition.lower() == 'true':
-            return True
-        return False
+        return strtobool(condition.strip().lower())
     except AttributeError:
         return bool(condition)
 
@@ -96,7 +95,8 @@ def parameter_condition(param_name, request=None, **kwargs):
         raise RequiredForCondition("request is required for condition "
                                    "'parameter'")
 
-    return request.GET.get(param_name) == 'True'
+    return param_name in request.GET
+    # return request.GET.get(param_name, '').lower() == 'true'
 
 
 @register('path matches')

--- a/flags/conditions.py
+++ b/flags/conditions.py
@@ -94,9 +94,12 @@ def parameter_condition(param_name, request=None, **kwargs):
     if request is None:
         raise RequiredForCondition("request is required for condition "
                                    "'parameter'")
+    try:
+        param_name, param_value = param_name.split('=')
+    except ValueError:
+        param_value = 'True'
 
-    return param_name in request.GET
-    # return request.GET.get(param_name, '').lower() == 'true'
+    return request.GET.get(param_name) == param_value
 
 
 @register('path matches')

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -67,10 +67,22 @@ class BooleanConditionTestCase(TestCase):
     def test_boolean_condition_valid_string(self):
         self.assertTrue(boolean_condition('True'))
         self.assertTrue(boolean_condition('true'))
+        self.assertTrue(boolean_condition('t'))
+        self.assertTrue(boolean_condition('yes'))
+        self.assertTrue(boolean_condition('y'))
+        self.assertTrue(boolean_condition('on'))
+        self.assertTrue(boolean_condition('1'))
+        self.assertTrue(boolean_condition(' true'))
+        self.assertTrue(boolean_condition('true   '))
 
     def test_boolean_condition_invalid_string(self):
         self.assertFalse(boolean_condition('False'))
         self.assertFalse(boolean_condition('false'))
+        self.assertFalse(boolean_condition('f'))
+        self.assertFalse(boolean_condition('no'))
+        self.assertFalse(boolean_condition('n'))
+        self.assertFalse(boolean_condition('off'))
+        self.assertFalse(boolean_condition('0'))
 
 
 class UserConditionTestCase(TestCase):
@@ -125,23 +137,25 @@ class ParameterConditionTestCase(TestCase):
         self.request = HttpRequest()
 
     def test_parameter_condition_valid(self):
-        self.request.GET = QueryDict('query_flag=True')
-        self.assertTrue(parameter_condition('query_flag',
-                                            request=self.request))
+        self.request.GET = QueryDict('my_flag=True')
+        self.assertTrue(parameter_condition('my_flag', request=self.request))
 
-    def test_parameter_condition_invalid(self):
-        self.request.GET = QueryDict('query_flag=False')
-        self.assertFalse(parameter_condition('query_flag',
-                                             request=self.request))
+        self.request.GET = QueryDict('my_flag=true')
+        self.assertTrue(parameter_condition('my_flag', request=self.request))
+
+        self.request.GET = QueryDict('my_flag=excellent')
+        self.assertTrue(parameter_condition('my_flag', request=self.request))
+
+        self.request.GET = QueryDict('my_flag')
+        self.assertTrue(parameter_condition('my_flag', request=self.request))
 
     def test_parameter_condition_non_existent(self):
-        self.request.GET = QueryDict('not_query_flag=True')
-        self.assertFalse(parameter_condition('query_flag',
-                                             request=self.request))
+        self.request.GET = QueryDict('not_my_flag=True')
+        self.assertFalse(parameter_condition('my_flag', request=self.request))
 
     def test_request_required(self):
         with self.assertRaises(RequiredForCondition):
-            parameter_condition('query_flag')
+            parameter_condition('my_flag')
 
 
 class PathConditionTestCase(TestCase):

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -140,18 +140,32 @@ class ParameterConditionTestCase(TestCase):
         self.request.GET = QueryDict('my_flag=True')
         self.assertTrue(parameter_condition('my_flag', request=self.request))
 
-        self.request.GET = QueryDict('my_flag=true')
-        self.assertTrue(parameter_condition('my_flag', request=self.request))
-
-        self.request.GET = QueryDict('my_flag=excellent')
-        self.assertTrue(parameter_condition('my_flag', request=self.request))
+        self.request.GET = QueryDict('my_flag=today')
+        self.assertTrue(
+            parameter_condition('my_flag=today', request=self.request)
+        )
 
         self.request.GET = QueryDict('my_flag')
-        self.assertTrue(parameter_condition('my_flag', request=self.request))
+        self.assertTrue(parameter_condition('my_flag=', request=self.request))
 
     def test_parameter_condition_non_existent(self):
-        self.request.GET = QueryDict('not_my_flag=True')
-        self.assertFalse(parameter_condition('my_flag', request=self.request))
+        self.request.GET = QueryDict('my_flag=True')
+        self.assertFalse(
+            parameter_condition('my_flag=false', request=self.request)
+        )
+
+        self.request.GET = QueryDict('my_flag=True')
+        self.assertFalse(
+            parameter_condition('my_flag=today', request=self.request)
+        )
+
+        self.request.GET = QueryDict('my_flag')
+        self.assertFalse(
+            parameter_condition('my_flag', request=self.request)
+        )
+
+        self.request.GET = QueryDict('')
+        self.assertFalse(parameter_condition('my_flag=', request=self.request))
 
     def test_request_required(self):
         with self.assertRaises(RequiredForCondition):


### PR DESCRIPTION
This PR makes small changes to the boolean and parameter conditions:

Boolean conditions can now match strings with superfluous whitespace around their values, so if, for example, `'  true  '` is entered as the value of the boolean condition, it will evaluate to `True`. Previously it did not.

Parameter conditions previously checked for `True` explicitly as the value of the parameter, i.e. `?my_flag=True`. This means other possible variations, `?my_flag=true`, `?my_flag=yesplease`, and just `?my_flag` would not work. [The documentation is ambiguous on the expected behavior of parameter conditions](https://cfpb.github.io/django-flags/conditions/#parameter), but the original intent was probably that any variation above would work. This PR clarifies the documentation and changes the implementation of the condition such that as long as the parameter exists in `request.GET` it will evaluate to `True`. This means ``?my_flag=True`, ?my_flag=true`, `?my_flag=yesplease`, and just `?my_flag` will all evaluate to `True`.

This PR closes #27 and closes #30.

