### PR TITLE
Document the flagged-class-based view API

### DIFF
--- a/docs/api/urls.md
+++ b/docs/api/urls.md
@@ -13,9 +13,9 @@ from flags.urls import flagged_path, flagged_paths, flagged_re_path, flagged_re_
 
 Make a URL depend on the state of a feature flag. 
 
-`flagged_path()` can be used in place of [Django's `path()`](https://docs.djangoproject.com/en/2.0/ref/urls/#django.urls.path).
+`flagged_path()` can be used in place of [Django's `path()`](https://docs.djangoproject.com/en/2.2/ref/urls/#django.urls.path).
 
-`flagged_re_path()` can be used in place of [Django's `re_path()`](https://docs.djangoproject.com/en/2.0/ref/urls/#django.urls.re_path).
+`flagged_re_path()` can be used in place of [Django's `re_path()`](https://docs.djangoproject.com/en/2.2/ref/urls/#django.urls.re_path).
 
 The `view` and the `fallback` can both be a set of `include()`ed patterns but any matching URL patterns in the includes must match *exactly* in terms of regular expression, keyword arguments, and name, otherwise a `404` may be unexpectedly raised. 
 
@@ -38,9 +38,9 @@ urlpatterns = [
 
 Flag multiple URLs in the same context with a context manager.
 
-`flagged_paths()` returns a function that takes the same arguments as [Django's `path()`](https://docs.djangoproject.com/en/2.0/ref/urls/#django.urls.path) and which will flag the pattern's view.
+`flagged_paths()` returns a function that takes the same arguments as [Django's `path()`](https://docs.djangoproject.com/en/2.2/ref/urls/#django.urls.path) and which will flag the pattern's view.
 
-`flagged_re_paths()` returns a function that takes the same arguments as [Django's `re_path()`](https://docs.djangoproject.com/en/2.0/ref/urls/#django.urls.re_path) and which will flag the pattern's view.
+`flagged_re_paths()` returns a function that takes the same arguments as [Django's `re_path()`](https://docs.djangoproject.com/en/2.2/ref/urls/#django.urls.re_path) and which will flag the pattern's view.
 
 ```python
 with flagged_paths('MY_FLAG') as path:

--- a/docs/api/views.md
+++ b/docs/api/views.md
@@ -1,0 +1,108 @@
+# Class-based views
+
+```python
+from flags.views import (
+    FlaggedViewMixin,
+    FlaggedTemplateView,
+)
+```
+
+## API
+
+### `FlaggedViewMixin`
+
+Adds flag-checking to HTTP method dispatching in [class-based views](https://docs.djangoproject.com/en/2.2/topics/class-based-views/).
+
+#### Attributes
+
+<dl>
+  <dt>`flag_name`</dt>
+  <dd>The feature flag this view depends on.</dd>
+
+  <dt>`state`</dt>
+  <dd>Either `True` or `False`, the state the feature flag should be in. By default, `state` is `True`, requiring the flag to evaluate to `True`.</dd>
+
+  <dt>`fallback`</dt>
+  <dd>A view to fallback on if the flag does not match the required `state`. Defaults to `None`, causing the to raise a `404` if the flag does not match the required `state`.</dd>
+</dl> 
+
+For example, in `views.py`:
+
+```python
+from django.views.generic import View
+from flags.views import FlaggedViewMixin
+
+class MyFlaggedView(FlaggedViewMixin, View):
+    def get(self, request, *args, **kwargs):
+        return HttpResponse('ok')
+```
+
+And in `urls.py`:
+
+```python
+from django.urls import path
+from flags.urls import flagged_path
+
+urlpatterns = [
+    path('my-url/', MyFlaggedView.as_view(flag_name='MY_FLAG'))
+]
+```
+
+#### Django 1.x
+
+```python
+from django.urls import path
+from flags.urls import flagged_path
+
+urlpatterns = [
+    url(r'^my-url/$', MyFlaggedView.as_view(flag_name='MY_FLAG'))
+]
+```
+
+### `FlaggedTemplateView`
+
+A combination of [`TemplateView`](https://docs.djangoproject.com/en/2.2/ref/class-based-views/base/#templateview) and [`FlaggedViewMixin`](#flaggedviewmixin).
+
+For example, in `views.py`:
+
+```python
+from flags.views import FlaggedTemplateView
+
+class MyFlaggedView(TemplateView):
+    template_name = "mytemplate.html"
+    flag_name = 'MY_FLAG'
+```
+
+Or to serve a template directly in `urls.py`:
+
+```
+from django.urls import path
+from flags.views import FlaggedTemplateView
+
+urlpatterns = [
+    path(
+        'my_url/', 
+        FlaggedTemplateView.as_view(
+            template_name='mytemplate.html', 
+            flag_name='MY_FLAG'
+        )
+    ),
+]
+```
+
+#### Django 1.x
+
+```
+from django.urls import url
+from flags.views import FlaggedTemplateView
+
+urlpatterns = [
+    url(
+        r'^my_url/$', 
+        FlaggedTemplateView.as_view(
+            template_name='mytemplate.html', 
+            flag_name='MY_FLAG'
+        )
+    ),
+]
+```

--- a/docs/api/views.md
+++ b/docs/api/views.md
@@ -23,7 +23,7 @@ Adds flag-checking to HTTP method dispatching in [class-based views](https://doc
   <dd>Either `True` or `False`, the state the feature flag should be in. By default, `state` is `True`, requiring the flag to evaluate to `True`.</dd>
 
   <dt>`fallback`</dt>
-  <dd>A view to fallback on if the flag does not match the required `state`. Defaults to `None`, causing the to raise a `404` if the flag does not match the required `state`.</dd>
+  <dd>A view to fallback on if the flag does not match the required `state`. Defaults to `None`, causing the view to raise a `404` if the flag does not match the required `state`.</dd>
 </dl> 
 
 For example, in `views.py`:
@@ -68,7 +68,7 @@ For example, in `views.py`:
 ```python
 from flags.views import FlaggedTemplateView
 
-class MyFlaggedView(TemplateView):
+class MyFlaggedView(FlaggedTemplateView):
     template_name = "mytemplate.html"
     flag_name = 'MY_FLAG'
 ```

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -73,4 +73,4 @@ FLAGS = {'MY_FLAG': {'before date': '2022-06-01T12:00Z'}}
 
 ## Custom conditions
 
-Custom conditions can be created and registered for use using the [conditions API](api/conditions).
+Custom conditions can be created and registered for use using the [conditions API](/api/conditions).

--- a/flags/views.py
+++ b/flags/views.py
@@ -1,13 +1,22 @@
+import logging
+import warnings
+
 from django.core.exceptions import ImproperlyConfigured
 from django.views.generic import TemplateView
 
 from flags.decorators import flag_check
 
 
+logger = logging.getLogger(__name__)
+
+
 class FlaggedViewMixin(object):
     flag_name = None
     fallback = None
-    condition = True
+    state = True
+
+    # condition will be deprecated in a future version, use state instead
+    condition = None
 
     def dispatch(self, request, *args, **kwargs):
         if self.flag_name is None:
@@ -15,11 +24,20 @@ class FlaggedViewMixin(object):
                 "FlaggedViewMixin requires a 'flag_name' argument."
             )
 
+        if self.condition is not None:
+            warnings.warn(
+                'condition attribute of FlaggedViewMixin is deprecated and '
+                'will be removed in a future version of Django-Flags. '
+                'Please use the state attribute instead.',
+                FutureWarning,
+            )
+            self.state = self.condition
+
         super_dispatch = super(FlaggedViewMixin, self).dispatch
 
         decorator = flag_check(
             self.flag_name,
-            self.condition,
+            self.state,
             fallback=self.fallback,
         )
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ pages:
         - Flag state: api/state.md
         - Flag decorators: api/decorators.md 
         - Flagged URL patterns: api/urls.md
+        - Class-based views : api/views.md
         - Django templates: api/django.md
         - Jinja2 templates: api/jinja2.md
         - Conditions: api/conditions.md


### PR DESCRIPTION
This PR adds documentation for the `FlaggedViewMixin` and `FlaggedTemplateView` classes that provide options for flagging class-based views.

It also deprecates the `condition` attribute on `FlaggedViewMixin`. The term "condition" has come to mean the thing that evaluates the state of the flag, rather than the expected evaluation. Using `condition` will not warn about its deprecation and recommend using `state` instead. This is now consistent with the use of the terms `condition` and `state` elsewhere in the Django-Flags API.

It also changes all our links to the Django 2.x docs to upcoming LTS release 2.2.

This PR will close #29.