### PR TITLE
Django 2.2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: python
 cache: pip
+dist: xenial
 
 matrix:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,12 @@ matrix:
       python: 3.6
     - env: TOXENV=py36-dj20
       python: 3.6
+    - env: TOXENV=py36-dj21
+      python: 3.6
+    - env: TOXENV=py37-dj21
+      python: 3.7
+    - env: TOXENV=py37-dj22
+      python: 3.7
     - env: TOXENV=docs
       python: 3.6
 

--- a/flags/tests/settings.py
+++ b/flags/tests/settings.py
@@ -30,6 +30,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.messages',
     'django.contrib.sessions',
 )
 
@@ -41,6 +42,7 @@ if django.VERSION >= (1, 10):  # pragma: no cover
     MIDDLEWARE = (
         'django.contrib.sessions.middleware.SessionMiddleware',
         'django.contrib.auth.middleware.AuthenticationMiddleware',
+        'django.contrib.messages.middleware.MessageMiddleware',
     )
 else:  # pragma: no cover
     MIDDLEWARE_CLASSES = (
@@ -48,16 +50,19 @@ else:  # pragma: no cover
         'django.contrib.auth.middleware.AuthenticationMiddleware',
     )
 
-TEMPLATES = [{
-    'BACKEND': 'django.template.backends.django.DjangoTemplates',
-    'APP_DIRS': True,
-    'OPTIONS': {
-        'context_processors': [
-            'django.template.context_processors.request',
-            'django.contrib.auth.context_processors.auth',
-        ],
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ]
+        },
     }
-}]
+]
 
 FLAGS = {
     'FLAG_ENABLED': [('boolean', True)],

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,7 @@ from setuptools import find_packages, setup
 
 long_description = open('README.md', 'r').read()
 
-install_requires = [
-    'Django>=1.11,<2.2',
-]
+install_requires = ['Django>=1.11,<2.3']
 
 testing_extras = [
     'mock>=2.0.0',
@@ -41,6 +39,7 @@ setup(
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
         'Framework :: Django :: 2.1',
+        'Framework :: Django :: 2.2',
         'License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication',
         'License :: Public Domain',
         'Programming Language :: Python',
@@ -48,5 +47,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
-    ]
+        'Programming Language :: Python :: 3.7',
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{27,36}-dj{111},py{36}-dj{20,21}
+envlist=lint,py{27,36}-dj{111},py{36,37}-dj{20,21,22}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -14,11 +14,13 @@ setenv=
 basepython=
     py27: python2.7
     py36: python3.6
+    py37: python3.7
 
 deps=
     dj111: Django>=1.11,<1.12
     dj20: Django>=2.0,<2.1
     dj21: Django>=2.1,<2.2
+    dj22: Django>=2.2,<2.3
 
 [testenv:lint]
 basepython=python3.6


### PR DESCRIPTION
[Django 2.2 was just released](https://docs.djangoproject.com/en/2.2/releases/2.2/) and is a new LTS release, which is unfortunately hard to install with `django-flags` being pinned to `'Django>=1.11,<2.2'`

This PR:

* Enables tests for Python 3.7 in Tox and Travis
* Enables tests for Django 2.2 in Tox and Travis
* Updates flags.tests.settings to be compatible with the Django 2.1+ checks regarding the admin's dependency on the messages app
* Updates Travis CI to use a version of Ubuntu which has Python 3.7 packages