### PR TITLE
Add notes to the docs about fallback view arguments

### DIFF
--- a/docs/api/decorators.md
+++ b/docs/api/decorators.md
@@ -1,6 +1,6 @@
 # Flag decorators
 
-Decorators are provided for use with Django views and conditions that take a `request` argument. The default behavior is to return a 404 if a callable fallback is not given.
+Decorators are provided for use with Django views and conditions that take a `request` argument. The default behavior is to return a 404 if a callable fallback is not given. 
 
 ```python
 from flags.decorators import (
@@ -15,7 +15,11 @@ from flags.decorators import (
 
 Check that a given flag has the given state. If the state does not match, perform the fallback.
 
-**Note**, because flags that do not exist are taken to be `False` by default, `@flag_check('MY_FLAG', False)` and `@flag_check('MY_FLAG', None)` will both succeed if `MY_FLAG` does not exist.
+!!! note
+    Because flags that do not exist are taken to be `False` by default, `@flag_check('MY_FLAG', False)` and `@flag_check('MY_FLAG', None)` will both succeed if `MY_FLAG` does not exist.
+
+!!! note
+    When a fallback view is given it *must* take the same arguments as the decorated view.
 
 ```python
 from flags.decorators import flag_check
@@ -36,11 +40,15 @@ def view_with_fallback(request):
     return HttpResponse('MY_FLAG_WITH_FALLBACK was True')
 ```
 
+
 ## Requiring state
 
 ### `flag_required(flag_name, fallback_view=None, pass_if_set=True)`
 
 Require the given flag to be enabled.
+
+!!! note
+    When a fallback view is given it *must* take the same arguments as the decorated view.
 
 ```python
 from flags.decorators import flag_required

--- a/docs/api/decorators.md
+++ b/docs/api/decorators.md
@@ -1,6 +1,6 @@
 # Flag decorators
 
-Decorators are provided for use with Django views and conditions that take a `request` argument. The default behavior is to return a 404 if a callable fallback is not given. 
+Decorators are provided for use with Django views and conditions that take a `request` argument. The default behavior is to return a 404 if a callable fallback is not given.
 
 ```python
 from flags.decorators import (

--- a/docs/api/urls.md
+++ b/docs/api/urls.md
@@ -21,6 +21,9 @@ The `view` and the `fallback` can both be a set of `include()`ed patterns but an
 
 If a `fallback` is not given the flagged url will raise a `404` if the flag state does not match the required `state`. 
 
+!!! note
+    When a fallback view is given it *must* take the same arguments as the flagged view.
+
 ```python
 urlpatterns = [
     flagged_path('MY_FLAG', 'a-url/', view_requiring_flag, state=True),
@@ -41,6 +44,9 @@ Flag multiple URLs in the same context with a context manager.
 `flagged_paths()` returns a function that takes the same arguments as [Django's `path()`](https://docs.djangoproject.com/en/2.2/ref/urls/#django.urls.path) and which will flag the pattern's view.
 
 `flagged_re_paths()` returns a function that takes the same arguments as [Django's `re_path()`](https://docs.djangoproject.com/en/2.2/ref/urls/#django.urls.re_path) and which will flag the pattern's view.
+
+!!! note
+    When a fallback view is given it *must* take the same arguments as the flagged view.
 
 ```python
 with flagged_paths('MY_FLAG') as path:
@@ -67,6 +73,9 @@ The `view` and the `fallback` can both be a set of `include()`ed patterns but an
 
 If a `fallback` is not given the flagged url will raise a `404` if the flag state does not match the required `state`. 
 
+!!! note
+    When a fallback view is given it *must* take the same arguments as the flagged view.
+
 ```python
 urlpatterns = [
     flagged_url('MY_FLAG', r'a-url/', view_requiring_flag, state=True),
@@ -84,6 +93,9 @@ urlpatterns = [
 Flag multiple URLs in the same context with a context manager.
 
 `flagged_urls()` returns a function that takes the same arguments as [Django's `url()`](https://docs.djangoproject.com/en/1.11/ref/urls/#django.conf.urls.url).
+
+!!! note
+    When a fallback view is given it *must* take the same arguments as the flagged view.
 
 ```python
 with flagged_urls('MY_FLAG') as url:

--- a/docs/api/views.md
+++ b/docs/api/views.md
@@ -26,6 +26,9 @@ Adds flag-checking to HTTP method dispatching in [class-based views](https://doc
   <dd>A view to fallback on if the flag does not match the required `state`. Defaults to `None`, causing the view to raise a `404` if the flag does not match the required `state`.</dd>
 </dl> 
 
+!!! note
+    When a fallback view is given it *must* take the same arguments as the flagged view.
+
 For example, in `views.py`:
 
 ```python

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ theme:
 extra_css:
     - css/overrides.css
 markdown_extensions:
+    - admonition
     - tables
     - markdown.extensions.tables
     - pymdownx.magiclink


### PR DESCRIPTION
Fallback views must take the same arguments and keyword arguments as the corresponding flagged view. This change adds that explicitly to the docs in all the places where the option exists to provide a fallback.

These admonitions look like:

<img width="717" alt="image" src="https://user-images.githubusercontent.com/10562538/57091424-28d00280-6cd7-11e9-80c0-c2ce7b28000e.png">
