### PR TITLE
Provide clarity around when feature flag state can be checked

### DIFF
--- a/docs/api/state.md
+++ b/docs/api/state.md
@@ -8,6 +8,11 @@ from flags.state import (
 )
 ```
 
+!!! note
+    If any of the flag state checking functions below is used at the top-level of a module (in `urls.py`, for example), it will be evaluated at import-time. This may have unintended consequences. [Database flag conditions](/api/sources/#flag-sources) may not be available, [custom conditions](/api/conditions/) may not be registered, and any dynamic change in flag state (such as date-based conditions or a newly added database condition) will not have an effect.
+
+    Consider using [the flagged URLs API](/api/urls/) for state-checking in `urls.py`, [the view decorators](/api/decorators/) and [the class-based view mixin](/api/views/) for state-checking Django views, and using these functions inside classes and functions. This will have the added benefit of ensuring that the intention is clear, and that flagged code is as tightly-scoped as possible.
+
 ## Checking state
 
 ### `flag_state(flag_name, **kwargs)`

--- a/docs/api/state.md
+++ b/docs/api/state.md
@@ -11,7 +11,7 @@ from flags.state import (
 !!! note
     If any of the flag state checking functions below is used at the top-level of a module (in `urls.py`, for example), it will be evaluated at import-time. This may have unintended consequences. [Database flag conditions](/api/sources/#flag-sources) may not be available, [custom conditions](/api/conditions/) may not be registered, and any dynamic change in flag state (such as date-based conditions or a newly added database condition) will not have an effect.
 
-    Consider using [the flagged URLs API](/api/urls/) for state-checking in `urls.py`, [the view decorators](/api/decorators/) and [the class-based view mixin](/api/views/) for state-checking Django views, and using these functions inside classes and functions. This will have the added benefit of ensuring that the intention is clear, and that flagged code is as tightly-scoped as possible.
+    Consider using [the flagged URLs API](/api/urls/) for state-checking in `urls.py`, [the view decorators](/api/decorators/) and [the class-based view mixin](/api/views/) for state-checking Django views, and using the state checking functions below inside methods and functions. This will have the added benefit of ensuring that the intention is clear, and that flagged code is as tightly-scoped as possible.
 
 ## Checking state
 

--- a/docs/api/urls.md
+++ b/docs/api/urls.md
@@ -98,9 +98,9 @@ Flag multiple URLs in the same context with a context manager.
     When a fallback view is given it *must* take the same arguments as the flagged view.
 
 ```python
-with flagged_urls('MY_FLAG') as url:
+with flagged_urls('MY_FLAG') as furl:
     flagged_url_patterns = [
-        url(^'a-url/', view_requiring_flag),
+        furl(^'a-url/', view_requiring_flag),
     ]
 
 urlpatterns = urlpatterns + flagged_url_patterns

--- a/flags/state.py
+++ b/flags/state.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+from django.apps import apps
+from django.core.exceptions import AppRegistryNotReady
+
 from flags.middleware import FlagConditionsMiddleware
 from flags.sources import get_flags
 
@@ -29,6 +32,12 @@ def _flag_state(flag_name, **kwargs):
 
 def flag_state(flag_name, **kwargs):
     """ Return the value for the flag by passing kwargs to its conditions """
+    if not apps.ready:
+        raise AppRegistryNotReady(
+            'Feature flag state cannot be checked before the app registry '
+            'is ready.'
+        )
+
     return _flag_state(flag_name, **kwargs)
 
 

--- a/flags/tests/test_decorators.py
+++ b/flags/tests/test_decorators.py
@@ -1,12 +1,15 @@
-try:
-    from unittest.mock import Mock
-except ImportError:  # pragma: no cover
-    from mock import Mock
+import warnings
 
 from django.http import Http404, HttpRequest, HttpResponse
 from django.test import TestCase
 
 from flags.decorators import flag_check, flag_required
+
+
+try:
+    from unittest.mock import Mock
+except ImportError:  # pragma: no cover
+    from mock import Mock
 
 
 class FlagCheckTestCase(TestCase):
@@ -15,18 +18,19 @@ class FlagCheckTestCase(TestCase):
         self.request.META['SERVER_NAME'] = 'localhost'
         self.request.META['SERVER_PORT'] = 8000
 
-        self.view = Mock(__name__='view')
+        self.mock_view = Mock(__name__='view')
+        self.view = lambda request: self.mock_view(request)
 
     def test_decorated_no_flag_exists(self):
         decorated = flag_check('FLAG_DOES_NOT_EXIST', True)(self.view)
         with self.assertRaises(Http404):
             decorated(self.request)
-        self.assertEqual(self.view.call_count, 0)
+        self.assertEqual(self.mock_view.call_count, 0)
 
     def test_decorated_flag_disabled(self):
         decorated = flag_check('FLAG_DISABLED', True)(self.view)
         self.assertRaises(Http404, decorated, self.request)
-        self.assertEqual(self.view.call_count, 0)
+        self.assertEqual(self.mock_view.call_count, 0)
 
     def test_decorated_flag_enabled(self):
         def view(request):
@@ -37,7 +41,7 @@ class FlagCheckTestCase(TestCase):
         self.assertContains(response, 'ok')
 
     def test_fallback_view(self):
-        def fallback(request):
+        def fallback(request, **kwargs):
             return HttpResponse('fallback')
 
         decorator = flag_check('FLAG_DISABLED', True, fallback=fallback)
@@ -64,10 +68,10 @@ class FlagCheckTestCase(TestCase):
     def test_pass_if_not_set_enabled(self):
         decorated = flag_check('FLAG_ENABLED', False)(self.view)
         self.assertRaises(Http404, decorated, self.request)
-        self.assertEqual(self.view.call_count, 0)
+        self.assertEqual(self.mock_view.call_count, 0)
 
     def test_pass_if_not_set_fallback_view(self):
-        def fallback(request):
+        def fallback(request, **kwargs):
             return HttpResponse('fallback')
 
         decorator = flag_check(
@@ -87,3 +91,30 @@ class FlagCheckTestCase(TestCase):
         decorated = flag_required('FLAG_ENABLED')(view)
         response = decorated(self.request)
         self.assertContains(response, 'ok')
+
+    def test_view_fallback_different_args(self):
+        def view(request, extra_arg, kwarg=None):
+            return HttpResponse('ok')  # pragma: no cover
+
+        def fallback(request):
+            return HttpResponse('fallback')  # pragma: no cover
+
+        decorator = flag_check('FLAG_DISABLED', True, fallback=fallback)
+        with warnings.catch_warnings(record=True) as warning_list:
+            decorator(view)
+
+            self.assertTrue(
+                any(item.category == RuntimeWarning for item in warning_list)
+            )
+
+    def test_view_fallback_same_args(self):
+        def view(request, extra_arg, kwarg=None):
+            return HttpResponse('ok')  # pragma: no cover
+
+        def fallback(request, extra_arg, kwarg=None):
+            return HttpResponse('fallback')
+
+        decorator = flag_check('FLAG_DISABLED', True, fallback=fallback)
+        decorated = decorator(view)
+        response = decorated(self.request, 'an extra argument', kwarg='foo')
+        self.assertContains(response, 'fallback')

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -1,9 +1,13 @@
-import mock
-
 from django.core.exceptions import AppRegistryNotReady
 from django.test import RequestFactory, TestCase
 
 from flags.state import flag_disabled, flag_enabled, flag_state
+
+
+try:
+    from unittest import mock
+except ImportError:  # pragma: no cover
+    import mock
 
 
 class FlagStateTestCase(TestCase):

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -1,3 +1,6 @@
+import mock
+
+from django.core.exceptions import AppRegistryNotReady
 from django.test import RequestFactory, TestCase
 
 from flags.state import flag_disabled, flag_enabled, flag_state
@@ -28,6 +31,12 @@ class FlagStateTestCase(TestCase):
         request = self.factory.get('/test')
         self.assertFalse(flag_state('FLAG_DOES_NOT_EXIST',
                                     request=request))
+
+    @mock.patch('flags.state.apps')
+    def test_flag_state_apps_not_ready(self, mock_apps):
+        mock_apps.ready = False
+        with self.assertRaises(AppRegistryNotReady):
+            self.assertTrue(flag_state('FLAG_ENABLED'))
 
     def test_flag_enabled_enabled(self):
         """ Global flags enabled should be True """

--- a/flags/tests/test_views.py
+++ b/flags/tests/test_views.py
@@ -28,8 +28,8 @@ class FlaggedViewMixinTestCase(TestCase):
         return request
 
     def test_no_flag_key_raises_improperly_configured(self):
-        view = TestView.as_view()
-        self.assertRaises(ImproperlyConfigured, view, self.request())
+        with self.assertRaises(ImproperlyConfigured):
+            TestView.as_view()
 
     def test_no_flag_acts_as_disabled(self):
         view = TestView.as_view(flag_name=self.flag_name)
@@ -63,7 +63,7 @@ class FlaggedViewMixinTestCase(TestCase):
         view = TestView.as_view(
             flag_name=self.flag_name,
             state=True,
-            fallback=lambda r: HttpResponse('fallback fn')
+            fallback=lambda r, *args, **kwargs: HttpResponse('fallback fn')
         )
 
         response = view(self.request())

--- a/flags/tests/test_views.py
+++ b/flags/tests/test_views.py
@@ -60,10 +60,11 @@ class FlaggedViewMixinTestCase(TestCase):
 
     @override_settings(FLAGS={'FLAGGED_VIEW_MIXIN': [('boolean', True)]})
     def test_fallback_view_function_enabled(self):
+        fallback = lambda request, *args, **kwargs: HttpResponse('fallback fn')
         view = TestView.as_view(
             flag_name=self.flag_name,
             state=True,
-            fallback=lambda r, *args, **kwargs: HttpResponse('fallback fn')
+            fallback=fallback
         )
 
         response = view(self.request())

--- a/flags/views.py
+++ b/flags/views.py
@@ -2,8 +2,8 @@ import logging
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured
-from django.views.generic import TemplateView
 from django.utils.decorators import classonlymethod
+from django.views.generic import TemplateView
 
 from flags.decorators import flag_check
 


### PR DESCRIPTION
This PR is intended to better communicate to users of Django-Flags various expectations and assumptions that get made but that aren't always obvious (even to me). These include:

- That feature flag state can't be checked before the app registry is ready
- That flag state can't be checked at import-time of modules that Django loads when starting up (like urls.py)
- FlaggedViewMixin now constructs its decorated view at `as_view()` call time rather than at request time. This should ensure that any errors are reported at start-up rather than in a request cycle.
- Fallback functions that do not take the same arguments as their corresponding flagged functions will now raise a `RuntimeWarning`. Along with #38, this closes #37.

