### PR TITLE
Add logging to flag state checking

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -62,11 +62,11 @@ Previously flag definitions in `FLAGS` supported a single dictionary (rather tha
 
 Default: `True`
 
-If this setting is `True` Django-Flags will log all flag state checks that evaluate to True. These will appear in the log file like:
+If this setting is `True` Django-Flags will log all flag state checks with how the conditions were evaluated. These will appear in the log file like:
 
 ```
-INFO:flags.sources:Flag MY_FLAG evaluated to True by boolean condition.
-INFO:flags.sources:Flag MY_FLAG evaluated to True by boolean, path matches conditions.
+INFO:flags.sources:Flag MY_FLAG evaluated False with conditions: boolean (False).
+INFO:flags.sources:Flag MY_FLAG evaluated True with conditions: boolean (False), path matches (True).
 ```
 
 This is intended for use in tracking the history and usage of enabled featured flags.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -57,3 +57,16 @@ FLAGS = {
 ```
 
 Previously flag definitions in `FLAGS` supported a single dictionary (rather than a list) with the condition name as the key and expected value as value. This method of specifying flags is deprecated and will be removed in Django-Flags 5.0.
+
+### `FLAGS_STATE_LOGGING`
+
+Default: `True`
+
+If this setting is `True` Django-Flags will log all flag state checks that evaluate to True. These will appear in the log file like:
+
+```
+INFO:flags.sources:Flag MY_FLAG evaluated to True by boolean condition.
+INFO:flags.sources:Flag MY_FLAG evaluated to True by boolean, path matches conditions.
+```
+
+This is intended for use in tracking the history and usage of enabled featured flags.

--- a/flags/sources.py
+++ b/flags/sources.py
@@ -69,18 +69,18 @@ class Flag(object):
             )
         )
 
-        if state and getattr(settings, 'FLAGS_STATE_LOGGING', True):
-            true_conditions = [
-                c.condition for c, s in checked_conditions if s is True
-            ]
-
+        if getattr(settings, 'FLAGS_STATE_LOGGING', True):
             logger.info(
-                'Flag {name} evaluated to {state} by '
-                '{conditions} condition{conditions_plural}.'.format(
+                'Flag {name} evaluated {state} with '
+                'condition{conditions_plural}: {conditions}.'.format(
                     name=self.name,
                     state=state,
-                    conditions=', '.join(true_conditions),
-                    conditions_plural='s' if len(true_conditions) > 1 else '',
+                    conditions=', '.join(
+                        '{} ({})'.format(c.condition, v)
+                        for c, v in checked_conditions
+                    ),
+                    conditions_plural='s' if len(self.conditions) > 1 else '',
+
                 )
             )
 

--- a/flags/sources.py
+++ b/flags/sources.py
@@ -34,6 +34,12 @@ class Flag(object):
     def __init__(self, name, conditions=[]):
         self.name = name
         self.conditions = conditions
+        self.optional_conditions = [
+            c for c in self.conditions if not c.required
+        ]
+        self.required_conditions = [
+            c for c in self.conditions if c.required
+        ]
 
     def __eq__(self, other):
         """ There can be only one feature flag of a given name """
@@ -41,19 +47,44 @@ class Flag(object):
 
     def check_state(self, **kwargs):
         """ Determine this flag's state based on any of its conditions """
-        not_required = [c for c in self.conditions if not c.required]
-        required = [c for c in self.conditions if c.required]
-
-        if len(not_required) == 0 and len(required) == 0:
+        if (len(self.optional_conditions) == 0
+                and len(self.required_conditions) == 0):
             return False
 
-        return (
-            any(c.check(**kwargs) for c in not_required)
-            if len(not_required) > 0
+        checked_conditions = [
+            (c, c.check(**kwargs)) for c in self.conditions
+        ]
+
+        state = (
+            any(
+                state for c, state in checked_conditions
+                if c in self.optional_conditions
+            )
+            if len(self.optional_conditions) > 0
             else True
         ) and (
-            all(c.check(**kwargs) for c in required)
+            all(
+                state for c, state in checked_conditions
+                if c in self.required_conditions
+            )
         )
+
+        if state and getattr(settings, 'FLAGS_STATE_LOGGING', True):
+            true_conditions = [
+                c.condition for c, s in checked_conditions if s is True
+            ]
+
+            logger.info(
+                'Flag {name} evaluated to {state} by '
+                '{conditions} condition{conditions_plural}.'.format(
+                    name=self.name,
+                    state=state,
+                    conditions=', '.join(true_conditions),
+                    conditions_plural='s' if len(true_conditions) > 1 else '',
+                )
+            )
+
+        return state
 
 
 class SettingsFlagsSource(object):

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -168,7 +168,7 @@ class FlagTestCase(TestCase):
     @skipIf(six.PY2, 'assertLogs is not available in Python 2.7')
     def test_flag_check_state_logs_state(self):
         flag = Flag('MY_FLAG', [
-            Condition('boolean', True),
+            Condition('boolean', False),
             Condition('path matches', '/foo')
         ])
         with self.assertLogs('flags.sources', level='INFO') as logger:
@@ -178,10 +178,10 @@ class FlagTestCase(TestCase):
         self.assertEqual(
             logger.output,
             [
-                'INFO:flags.sources:Flag MY_FLAG evaluated to True by '
-                'boolean condition.',
-                'INFO:flags.sources:Flag MY_FLAG evaluated to True by '
-                'boolean, path matches conditions.',
+                'INFO:flags.sources:Flag MY_FLAG evaluated False with '
+                'conditions: boolean (False), path matches (False).',
+                'INFO:flags.sources:Flag MY_FLAG evaluated True with '
+                'conditions: boolean (False), path matches (True).'
             ]
         )
 


### PR DESCRIPTION
This PR adds `INFO`-level logging to flag state checking when flag state is True with the conditions that were met. This depends on a new setting, `FLAGS_STATE_LOGGING`, which defaults to `True`.

The logging looks like this:

```
INFO:flags.sources:Flag MY_FLAG evaluated False with conditions: boolean (False).
INFO:flags.sources:Flag MY_FLAG evaluated True with conditions: boolean (False), path matches (True).
```

This should help track the history and usage of flags, without depending on the particularities of conditions (i.e. we don't record when a 'boolean' condition is set to `True`, instead we record when checks are made that end with the flag state being `True`). 