### PR TITLE
Fix link to conditions API

### DIFF
--- a/docs/api/sources.md
+++ b/docs/api/sources.md
@@ -1,6 +1,6 @@
 # Flag Sources
 
-Django-Flags provides a means to provide custom flag sources using the [`FLAG_SOURCES` setting](../settings/#flag_sources). Flag sources are classes that provide a `get_flags` method. The `get_flags` method must return a dictionary of flag name keys with a list of [`Condition`](#conditioncondition-value-sourcenone-objnone) objects.
+Django-Flags provides a means to provide custom flag sources using the [`FLAG_SOURCES` setting](../../settings/#flag_sources). Flag sources are classes that provide a `get_flags` method. The `get_flags` method must return a dictionary of flag name keys with a list of [`Condition`](#conditioncondition-value-requiredfalse) objects.
 
 ```python
 from flags.sources import Condition
@@ -21,7 +21,7 @@ class CustomFlagSource(object):
 
 ### `get_flags(sources=None, ignore_errors=False)`
 
-Return a dictionary of all flag names with [`Flag`](#flagname-conditions) objects that are available in the given `sources`. If `sources` is not given, the sources in the [`FLAG_SOURCES` setting](../settings/#flag_sources) are used. If `ignore_errors` is `True`, any exceptions that occur when getting flags from a source will be caught and ignored.
+Return a dictionary of all flag names with [`Flag`](#flagname-conditions) objects that are available in the given `sources`. If `sources` is not given, the sources in the [`FLAG_SOURCES` setting](../../settings/#flag_sources) are used. If `ignore_errors` is `True`, any exceptions that occur when getting flags from a source will be caught and ignored.
 
 ### `Condition(condition, value, required=False)`
 
@@ -33,7 +33,7 @@ Check the condition against the given keyword arguments.
 
 ### `Flag(name, conditions=[])`
 
-A simple wrapper around flags and their conditions. `conditions` is a list of [`Condition`](#conditioncondition-value-sourcenone-objnone) objects.
+A simple wrapper around flags and their conditions. `conditions` is a list of [`Condition`](#conditioncondition-value-requiredfalse) objects.
 
 #### `Flag.check_state(*kwargs)`
 

--- a/docs/api/urls.md
+++ b/docs/api/urls.md
@@ -1,6 +1,6 @@
 # Flagged URL patterns
 
-Flagged URL patterns are an alternative to [flagging views with decorators](https://github.com/cfpb/wagtail-flags#flag_checkflag_name-state-fallbacknone-kwargs).
+Flagged URL patterns are an alternative to [flagging views with decorators](../../api/decorators).
 
 ## Django 2.0+
 

--- a/docs/conditions.md
+++ b/docs/conditions.md
@@ -73,4 +73,4 @@ FLAGS = {'MY_FLAG': {'before date': '2022-06-01T12:00Z'}}
 
 ## Custom conditions
 
-Custom conditions can be created and registered for use using the [conditions API](/api/conditions).
+Custom conditions can be created and registered for use using the [conditions API](../api/conditions).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Django-Flags
 
-Feature flags allow you to toggle functionality in both Django code and the Django templates based on configurable conditions. Flags can be useful for staging feature deployments, for A/B testing, or for any time you need an on/off switch for blocks of code. The toggle can be by date, user, URL value, or a number of [other conditions](conditions), editable in the admin or in definable in settings.
+Feature flags allow you to toggle functionality in both Django code and the Django templates based on configurable conditions. Flags can be useful for staging feature deployments, for A/B testing, or for any time you need an on/off switch for blocks of code. The toggle can be by date, user, URL value, or a number of [other conditions](./conditions), editable in the admin or in definable in settings.
 
 ## Dependencies
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -6,7 +6,7 @@
 
 Default: `('flags.sources.SettingsFlagsSource', 'flags.sources.DatabaseFlagsSource',)`
 
-A list or tuple containing the full Python path strings to classes that provides a [`get_flags()` method](api/sources/#flag-sources). The `get_flags()` method is expected to return a dictionary of flags and [`Condition` objects](api/sources/#conditioncondition-value-sourcenone-objnone). All flags returned by all flag sources will be available to check.
+A list or tuple containing the full Python path strings to classes that provides a [`get_flags()` method](../api/sources/#flag-sources). The `get_flags()` method is expected to return a dictionary of flags and [`Condition` objects](../api/sources/#conditioncondition-value-sourcenone-objnone). All flags returned by all flag sources will be available to check.
 
 ### `FLAGS`
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -2,17 +2,17 @@
 
 ## Defining flags
 
-### `FLAGS_SOURCES`
+### `FLAG_SOURCES`
 
 Default: `('flags.sources.SettingsFlagsSource', 'flags.sources.DatabaseFlagsSource',)`
 
-A list or tuple containing the full Python path strings to classes that provides a [`get_flags()` method](../api/sources/#flag-sources). The `get_flags()` method is expected to return a dictionary of flags and [`Condition` objects](../api/sources/#conditioncondition-value-sourcenone-objnone). All flags returned by all flag sources will be available to check.
+A list or tuple containing the full Python path strings to classes that provides a [`get_flags()` method](../api/sources/#flag-sources). The `get_flags()` method is expected to return a dictionary of flags and [`Condition` objects](../api/sources/#conditioncondition-value-requiredfalse). All flags returned by all flag sources will be available to check.
 
 ### `FLAGS`
 
 Default: `{}`
 
-A dictionary of feature flags and optional conditions used when `'flags.sources.SettingsFlagsSource'` is in [`FLAGS_SOURCES`](#flag_sources).
+A dictionary of feature flags and optional conditions used when `'flags.sources.SettingsFlagsSource'` is in [`FLAG_SOURCES`](#flag_sources).
 
 Conditions can either be included as:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,7 @@ FLAGS = {
 
 The set of conditions can be empty (flag will never be enabled), have one or more conditions that are not required (any of those conditions can be met for the flag to be enabled), or one or more required conditions (all required conditions have to be met for the flag to be enabled).
 
-Additional conditions can be added in the Django admin for any defined flag (illustrated in [Quickstart](../#quickstart)). Conditions added in the Django admin can be changed without restarting Django, conditions defined in `settings.py` cannot. See [the list of built-in conditions](conditions).
+Additional conditions can be added in the Django admin for any defined flag (illustrated in [Quickstart](../#quickstart)). Conditions added in the Django admin can be changed without restarting Django, conditions defined in `settings.py` cannot. See [the list of built-in conditions](../conditions/).
 
 ## Using flags in code
 
@@ -45,7 +45,7 @@ Django templates:
 {% endif %}
 ```
 
-Jinja2 templates (after [adding `flag_enabled` to the Jinja2 environment](api/jinja2/)):
+Jinja2 templates (after [adding `flag_enabled` to the Jinja2 environment](../api/jinja2/)):
 
 ```jinja
 {% if flag_enabled('FLAG_WITH_ANY_CONDITIONS', request) %}
@@ -75,4 +75,4 @@ urlpatterns = [
 ]
 ```
 
-See the [API reference](/api/state) for more details and examples.
+See the [API reference](../api/state) for more details and examples.


### PR DESCRIPTION
The link at the bottom of [the Conditions documentation page](https://cfpb.github.io/django-flags/conditions/) is currently broken and doesn't work when the documentation isn't hosted at the root of the domain.

This commit fixes the link.