### PR TITLE
Fix supported versions of Django in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Feature flags allow you to toggle functionality in both Django code and the Djan
 
 ## Dependencies
 
-- Django 1.8+ (including Django 2.0)
+- Django 1.11+ (including Django 2.x)
 - Python 2.7+, 3.6+
 
 ## Installation


### PR DESCRIPTION
Closes #43. We never updated the supported versions of Django in the README when we dropped support for Django 1.8 in 4.0.0. This PR fixes that.