### PR TITLE
Use clearer language for booleans with required conditions

### DIFF
--- a/flags/templatetags/flags_debug.py
+++ b/flags/templatetags/flags_debug.py
@@ -31,47 +31,66 @@ def state_str(flag):
 
     is_enabled = bool_enabled(flag)
 
+    # Common strings
+    enabled_str = _('<b>enabled</b>')
+    disabled_str = _('<b>disabled</b>')
+    all_requests_str = _('for all requests')
+    enabled_all_requests_str = _(' ' + enabled_str + ' ' + all_requests_str)
+    disabled_all_requests_str = _(' ' + disabled_str + ' ' + all_requests_str)
+
+    # Start building the state string
     state_str = flag.name + _(' is')
 
+    # If we don't have required boolean conditions, we can rely on is_enabled
     if len(req_bool_conditions) > 0:
         if is_enabled:
-            state_str += _(' <b>enabled</b> for all requests')
+            state_str += enabled_all_requests_str
         else:
-            state_str += _(' <b>disabled</b> for all requests')
+            state_str += disabled_all_requests_str
 
+    # Otherwise we have to dig into all the non-boolean conditions and figure
+    # out what the state string should say
     elif len(non_bool_conditions) > 0:
+
+        # Are there required conditions?
         if len(req_conditions) > 0:
-            state_str += _(' <b>')
 
             if (len(bool_conditions) > 0 and
                     len(non_bool_conditions) == len(req_conditions) and
                     not is_enabled):
-                state_str += _('disabled')
+                # state_str += _(' <b>disabled</b> for all requests, even')
+                state_str += disabled_all_requests_str
+                state_str += _(', even')
             else:
-                state_str += _('enabled')
+                state_str += ' ' + enabled_str
 
-            state_str += _('</b>')
             state_str += _(' when <i>all</i> required conditions')
 
             if len(non_bool_conditions) == len(req_conditions):
                 state_str += _(' are met')
 
+        # If there aren't any required conditions, it's simpler.
         elif is_enabled:
-            state_str += _(' <b>enabled</b> for all requests')
+            state_str += ' ' + enabled_str + _(' for all requests')
         else:
-            state_str += _(' <b>enabled</b> when')
+            state_str += ' ' + enabled_str + _(' when')
 
+        # If there are non-required conditions, we should say something about
+        # them too.
         if not is_enabled:
             if len(non_bool_conditions) > len(req_conditions):
                 if len(req_conditions) > 0:
                     state_str += _(' and')
                 state_str += _(' <i>any</i> optional condition is met')
 
+    # Finally, if there are no non-boolean conditions and no required boolean
+    # conditions, we can just say it's enabled or disabled for all requests.
     elif is_enabled:
-        state_str += _(' <b>enabled</b> for all requests')
+        state_str += enabled_all_requests_str
     else:
-        state_str += _(' <b>disabled</b> for all requests')
+        state_str += disabled_all_requests_str
 
+    # Full stop.
     state_str += '.'
 
     return mark_safe(state_str)

--- a/flags/tests/test_templatetags_flags_debug.py
+++ b/flags/tests/test_templatetags_flags_debug.py
@@ -70,8 +70,8 @@ class TestStateStrTemplateTag(TestCase):
     def test_state_str_required_no_optional_bool_false(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
-            'MYFLAG is <b>disabled</b> when <i>all</i> required conditions '
-            'are met.',
+            'MYFLAG is <b>disabled</b> for all requests, '
+            'even when <i>all</i> required conditions are met.',
             state_str(flag)
         )
 


### PR DESCRIPTION
This change will say 'MYFLAG is disabled for all requests, even when all required conditions are met.' when there are required conditions along with a non-required boolean condition and no other non-required conditions.

This is a change from 'MYFLAG is disabled when all required conditions are met.' which is somewhat confusing.

This change also refactors the string creation somewhat to reduce the duplication of strings. Hopefully the way I'm slicing makes eventual translation doable... but I'm not entirely sure that'll be the case.

With the [Flag conditions Debug Toolbar panel](https://cfpb.github.io/django-flags/debugging/#flag-conditions) this looks like:

![image](https://user-images.githubusercontent.com/10562538/60023251-70ce2e80-9663-11e9-986c-85901ae4a2b8.png)


With https://github.com/cfpb/wagtail-flags/pull/35 this looks like:

![image](https://user-images.githubusercontent.com/10562538/60021349-dcae9800-965f-11e9-9f25-a152cb83a4da.png)
