### PR TITLE
Move optional/required condition filtering back to check_state()

### DIFF
--- a/flags/sources.py
+++ b/flags/sources.py
@@ -34,12 +34,6 @@ class Flag(object):
     def __init__(self, name, conditions=[]):
         self.name = name
         self.conditions = conditions
-        self.optional_conditions = [
-            c for c in self.conditions if not c.required
-        ]
-        self.required_conditions = [
-            c for c in self.conditions if c.required
-        ]
 
     def __eq__(self, other):
         """ There can be only one feature flag of a given name """
@@ -47,8 +41,15 @@ class Flag(object):
 
     def check_state(self, **kwargs):
         """ Determine this flag's state based on any of its conditions """
-        if (len(self.optional_conditions) == 0
-                and len(self.required_conditions) == 0):
+        optional_conditions = [
+            c for c in self.conditions if not c.required
+        ]
+        required_conditions = [
+            c for c in self.conditions if c.required
+        ]
+
+        if (len(optional_conditions) == 0
+                and len(required_conditions) == 0):
             return False
 
         checked_conditions = [
@@ -58,14 +59,14 @@ class Flag(object):
         state = (
             any(
                 state for c, state in checked_conditions
-                if c in self.optional_conditions
+                if c in optional_conditions
             )
-            if len(self.optional_conditions) > 0
+            if len(optional_conditions) > 0
             else True
         ) and (
             all(
                 state for c, state in checked_conditions
-                if c in self.required_conditions
+                if c in required_conditions
             )
         )
 

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -212,6 +212,23 @@ class GetFlagsTestCase(TestCase):
         self.assertEqual(len(flags['OTHER_FLAG'].conditions), 0)
         self.assertEqual(len(flags['SOURCED_FLAG'].conditions), 1)
 
+    @override_settings(FLAGS={'MY_FLAG': []})
+    def test_get_flags_ensure_combined_conditions_work(self):
+        FlagState.objects.create(
+            name='MY_FLAG',
+            condition='boolean',
+            value='True'
+        )
+        flags = get_flags(
+            sources=[
+                'flags.sources.SettingsFlagsSource',
+                'flags.sources.DatabaseFlagsSource',
+            ]
+        )
+        self.assertIn('MY_FLAG', flags)
+        my_flag = flags['MY_FLAG']
+        self.assertTrue(my_flag.check_state())
+
     def test_ignore_errors(self):
         # Without ignore_errors
         with self.assertRaises(Exception):


### PR DESCRIPTION
755a11290c70f7048f479525a5593d3554cc0ae7 did some refactoring of when optional and required conditions are filtered. This has resulted in some issues where conditions aren't being correctly evaluated. 

Thanks to @chosak, the issue is [`conditions` is modified on the `Flag` object after `__init__` is called](https://github.com/cfpb/django-flags/blob/3481867933e1dc84e7cbddf53954c80ac8af0898/flags/sources.py#L186), but `optional_conditions` and `required_conditions` are never updated after `__init__`. 

This seems like it was a false optimization. This PR reverts it to fix the issue. 