### PR TITLE
Remove "optional" from state string language

### DIFF
--- a/flags/sources.py
+++ b/flags/sources.py
@@ -41,14 +41,14 @@ class Flag(object):
 
     def check_state(self, **kwargs):
         """ Determine this flag's state based on any of its conditions """
-        optional_conditions = [
+        non_required_conditions = [
             c for c in self.conditions if not c.required
         ]
         required_conditions = [
             c for c in self.conditions if c.required
         ]
 
-        if (len(optional_conditions) == 0
+        if (len(non_required_conditions) == 0
                 and len(required_conditions) == 0):
             return False
 
@@ -59,9 +59,9 @@ class Flag(object):
         state = (
             any(
                 state for c, state in checked_conditions
-                if c in optional_conditions
+                if c in non_required_conditions
             )
-            if len(optional_conditions) > 0
+            if len(non_required_conditions) > 0
             else True
         ) and (
             all(

--- a/flags/templates/flags/panels/flags.html
+++ b/flags/templates/flags/panels/flags.html
@@ -27,8 +27,6 @@
               <td>
                 {% if condition.required %}
                   {% trans "Required" %}
-                {% else %}
-                  {% trans "Optional" %}
                 {% endif %}
               </td>
             </tr>

--- a/flags/templatetags/flags_debug.py
+++ b/flags/templatetags/flags_debug.py
@@ -81,7 +81,10 @@ def state_str(flag):
             if len(non_bool_conditions) > len(req_conditions):
                 if len(req_conditions) > 0:
                     state_str += _(' and')
-                state_str += _(' <i>any</i> optional condition is met')
+                state_str += _(' <i>any</i>')
+                if len(req_conditions) > 0:
+                    state_str += _(' non-required')
+                state_str += _(' condition is met')
 
     # Finally, if there are no non-boolean conditions and no required boolean
     # conditions, we can just say it's enabled or disabled for all requests.

--- a/flags/templatetags/flags_debug.py
+++ b/flags/templatetags/flags_debug.py
@@ -66,7 +66,7 @@ def state_str(flag):
 
             state_str += _(' when <i>all</i> required conditions')
 
-            if len(non_bool_conditions) == len(req_conditions):
+            if len(non_bool_conditions) == len(req_conditions) or is_enabled:
                 state_str += _(' are met')
 
         # If there aren't any required conditions, it's simpler.

--- a/flags/tests/test_templatetags_flags_debug.py
+++ b/flags/tests/test_templatetags_flags_debug.py
@@ -43,7 +43,7 @@ class TestStateStrTemplateTag(TestCase):
     @override_settings(FLAGS={'MYFLAG': [
         ('anonymous', 'False', True),
     ]})
-    def test_state_str_required_no_optional_no_bool(self):
+    def test_state_str_required_no_non_required_no_bool(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
             'MYFLAG is <b>enabled</b> when <i>all</i> required conditions '
@@ -55,7 +55,7 @@ class TestStateStrTemplateTag(TestCase):
         ('anonymous', 'False', True),
         ('boolean', True),
     ]})
-    def test_state_str_required_no_optional_bool_true(self):
+    def test_state_str_required_no_non_required_bool_true(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
             'MYFLAG is <b>enabled</b> when <i>all</i> required conditions '
@@ -67,7 +67,7 @@ class TestStateStrTemplateTag(TestCase):
         ('anonymous', 'False', True),
         ('boolean', False),
     ]})
-    def test_state_str_required_no_optional_bool_false(self):
+    def test_state_str_required_no_non_required_bool_false(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
             'MYFLAG is <b>disabled</b> for all requests, '
@@ -80,11 +80,11 @@ class TestStateStrTemplateTag(TestCase):
         ('path matches', '/mypath'),
         ('boolean', False),
     ]})
-    def test_state_str_required_optional_bool_false(self):
+    def test_state_str_required_non_required_bool_false(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
             'MYFLAG is <b>enabled</b> when <i>all</i> required conditions '
-            'and <i>any</i> optional condition is met.',
+            'and <i>any</i> non-required condition is met.',
             state_str(flag)
         )
 
@@ -93,7 +93,7 @@ class TestStateStrTemplateTag(TestCase):
         ('boolean', True, True),
         ('path matches', '/mypath'),
     ]})
-    def test_state_str_required_optional_bool_true_required(self):
+    def test_state_str_required_non_required_bool_true_required(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
             'MYFLAG is <b>enabled</b> for all requests.',
@@ -105,7 +105,7 @@ class TestStateStrTemplateTag(TestCase):
         ('boolean', False, True),
         ('path matches', '/mypath'),
     ]})
-    def test_state_str_required_optional_bool_false_required(self):
+    def test_state_str_required_non_required_bool_false_required(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
             'MYFLAG is <b>disabled</b> for all requests.',
@@ -116,7 +116,7 @@ class TestStateStrTemplateTag(TestCase):
         ('anonymous', 'False'),
         ('boolean', True),
     ]})
-    def test_state_str_no_required_optional_bool_true(self):
+    def test_state_str_no_required_non_required_bool_true(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
             'MYFLAG is <b>enabled</b> for all requests.',
@@ -127,21 +127,21 @@ class TestStateStrTemplateTag(TestCase):
         ('anonymous', 'False', True),
         ('path matches', '/mypath'),
     ]})
-    def test_state_str_required_optional_no_bool(self):
+    def test_state_str_required_non_required_no_bool(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
             'MYFLAG is <b>enabled</b> when <i>all</i> required conditions '
-            'and <i>any</i> optional condition is met.',
+            'and <i>any</i> non-required condition is met.',
             state_str(flag)
         )
 
     @override_settings(FLAGS={'MYFLAG': [
         ('path matches', '/mypath'),
     ]})
-    def test_state_str_non_bool_optional(self):
+    def test_state_str_non_bool_non_required(self):
         flag = get_flags().get('MYFLAG')
         self.assertEqual(
-            'MYFLAG is <b>enabled</b> when <i>any</i> optional condition '
+            'MYFLAG is <b>enabled</b> when <i>any</i> condition '
             'is met.',
             state_str(flag)
         )

--- a/flags/tests/test_templatetags_flags_debug.py
+++ b/flags/tests/test_templatetags_flags_debug.py
@@ -136,6 +136,19 @@ class TestStateStrTemplateTag(TestCase):
         )
 
     @override_settings(FLAGS={'MYFLAG': [
+        ('anonymous', 'False', True),
+        ('path matches', '/mypath'),
+        ('boolean', True)
+    ]})
+    def test_state_str_required_non_required_bool(self):
+        flag = get_flags().get('MYFLAG')
+        self.assertEqual(
+            'MYFLAG is <b>enabled</b> when <i>all</i> required conditions '
+            'are met.',
+            state_str(flag)
+        )
+
+    @override_settings(FLAGS={'MYFLAG': [
         ('path matches', '/mypath'),
     ]})
     def test_state_str_non_bool_non_required(self):


### PR DESCRIPTION
"Optional" does not seem like the right word to use in retrospect. The difference between required and non-required conditions is the difference between a boolean AND and a boolean OR. So, no condition is "optional" — at least one of them has to be met.

This change removes the word "optional" from the state string when there are no required conditions, and replaces it with "non-required" when there are.

It also removes "optional" from the code in places where we refer to conditions that are not required. 