### PR TITLE
Update tests badge in README to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Django-Flags
 
-[![Build Status](https://travis-ci.org/cfpb/django-flags.svg?branch=master)](https://travis-ci.org/cfpb/django-flags)
+[![Build Status](https://github.com/cfpb/django-flags/workflows/Tests/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/cfpb/django-flags/badge.svg?branch=master)](https://coveralls.io/github/cfpb/django-flags?branch=master)
 
 Feature flags allow you to toggle functionality in both Django code and the Django templates based on configurable conditions. Flags can be useful for staging feature deployments, for A/B testing, or for any time you need an on/off switch for blocks of code. The toggle can be by date, user, URL value, or a number of [other conditions](https://cfpb.github.io/django-flags/conditions/), editable in the admin or in definable in settings.


### PR DESCRIPTION
This is a simple change following #52 to change the badge in the README from Travis to GitHub Actions.