### PR TITLE
Fix Coveralls with GitHub Acitons

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,11 @@
-name: Tests
+name: test
 
 on: [push]
 
 jobs:
 
   lint:
-    name: Linting
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
@@ -26,7 +26,7 @@ jobs:
           TOXENV: lint
 
   test:
-    name: Unit tests
+    name: unittests
     runs-on: ubuntu-latest
 
     strategy:
@@ -69,28 +69,9 @@ jobs:
           pip install tox coveralls
 
       - name: Run tox
-        run: tox
+        run: |
+            tox
+            coveralls
         env: 
           TOXENV: ${{ matrix.toxenv }}
-
-  coverage:
-    name: Coverage
-    needs: [test]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-
-      - name: Set up Python
-        uses: actions/setup-python@v1
-        with:
-          python-version: 3.7
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install coveralls
-
-      - name: Submit coverage 
-        run: coveralls
-        env: 
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Django-Flags
 
-[![Build Status](https://github.com/cfpb/django-flags/workflows/Tests/badge.svg)
+[![Build Status](https://github.com/cfpb/django-flags/workflows/test/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/cfpb/django-flags/badge.svg?branch=master)](https://coveralls.io/github/cfpb/django-flags?branch=master)
 
 Feature flags allow you to toggle functionality in both Django code and the Django templates based on configurable conditions. Flags can be useful for staging feature deployments, for A/B testing, or for any time you need an on/off switch for blocks of code. The toggle can be by date, user, URL value, or a number of [other conditions](https://cfpb.github.io/django-flags/conditions/), editable in the admin or in definable in settings.


### PR DESCRIPTION
This PR removes the separate Coverage job in our tests action, puts coveralls submission in the unit test steps, and renames the jobs to be consistently cased with other non-GitHub Actions checks.

This, and deleting django-flags from Coveralls and re-adding it, seems to fix the coverage reporting.

