### PR TITLE
Use our PEP8-specified line length

### DIFF
--- a/flags/sources.py
+++ b/flags/sources.py
@@ -46,10 +46,7 @@ class Flag(object):
         ]
         required_conditions = [c for c in self.conditions if c.required]
 
-        if (
-            len(non_required_conditions) == 0
-            and len(required_conditions) == 0
-        ):
+        if len(non_required_conditions) == 0 and len(required_conditions) == 0:
             return False
 
         checked_conditions = [(c, c.check(**kwargs)) for c in self.conditions]

--- a/flags/tests/test_conditions.py
+++ b/flags/tests/test_conditions.py
@@ -85,9 +85,7 @@ class BooleanConditionTestCase(TestCase):
 
 class UserConditionTestCase(TestCase):
     def setUp(self):
-        user = User.objects.create_user(
-            username="testuser", email="test@user"
-        )
+        user = User.objects.create_user(username="testuser", email="test@user")
         self.request = HttpRequest()
         self.request.user = user
 
@@ -160,9 +158,7 @@ class ParameterConditionTestCase(TestCase):
         self.assertFalse(parameter_condition("my_flag", request=self.request))
 
         self.request.GET = QueryDict("")
-        self.assertFalse(
-            parameter_condition("my_flag=", request=self.request)
-        )
+        self.assertFalse(parameter_condition("my_flag=", request=self.request))
 
     def test_request_required(self):
         with self.assertRaises(RequiredForCondition):

--- a/flags/tests/test_models.py
+++ b/flags/tests/test_models.py
@@ -8,9 +8,7 @@ class FlagStateTestCase(TestCase):
         state = FlagState.objects.create(
             name="MY_FLAG", condition="boolean", value="True"
         )
-        self.assertEqual(
-            str(state), "MY_FLAG is enabled when boolean is True"
-        )
+        self.assertEqual(str(state), "MY_FLAG is enabled when boolean is True")
 
     def test_flag_str_required(self):
         state = FlagState.objects.create(

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -175,9 +175,7 @@ class FlagTestCase(TestCase):
 
 class GetFlagsTestCase(TestCase):
     def test_get_flags_from_sources(self):
-        flags = get_flags(
-            sources=["flags.tests.test_sources.TestFlagsSource"]
-        )
+        flags = get_flags(sources=["flags.tests.test_sources.TestFlagsSource"])
         self.assertTrue(flags["SOURCED_FLAG"].conditions[0].value)
         self.assertIn("NOT_IN_SETTINGS_FLAG", flags)
 

--- a/flags/tests/test_urls.py
+++ b/flags/tests/test_urls.py
@@ -248,9 +248,7 @@ class FlagCheckTestCase(TestCase):
             )
 
     @override_settings(FLAGS={"FLAGGED_URL": [("boolean", False)]})
-    def test_flagged_url_false_include_fallback_include_nonmatching_url(
-        self,
-    ):
+    def test_flagged_url_false_include_fallback_include_nonmatching_url(self,):
         response = self.get_url_response(
             "/include-fallback-include/other-included-url"
         )

--- a/flags/tests/test_views.py
+++ b/flags/tests/test_views.py
@@ -58,9 +58,7 @@ class FlaggedViewMixinTestCase(TestCase):
 
     @override_settings(FLAGS={"FLAGGED_VIEW_MIXIN": [("boolean", True)]})
     def test_fallback_view_function_enabled(self):
-        fallback = lambda request, *args, **kwargs: HttpResponse(
-            "fallback fn"
-        )
+        fallback = lambda request, *args, **kwargs: HttpResponse("fallback fn")
         view = TestView.as_view(
             flag_name=self.flag_name, state=True, fallback=fallback
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-line-length = 78
+line-length = 79
 target-version = ['py36', 'py38']
 include = '\.pyi?$'
 exclude = '''


### PR DESCRIPTION
This follows on from #56. Our [development standards](https://github.com/cfpb/development/blob/master/standards/python.md#linting) refer to PEP8 for line length. This change fixes an error that specified lines be 78 instead of 79 for black.