### PR TITLE
Add support for Django 3.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
@@ -33,24 +33,24 @@ jobs:
       matrix:
         toxenv:
             - py36-dj111
-            - py36-dj20
-            - py36-dj21
             - py36-dj22
-            - py37-dj21
-            - py37-dj22
+            - py36-dj30
+            - py38-dj111
+            - py38-dj22
+            - py38-dj30
         include:
           - toxenv: py36-dj111
             python-version: 3.6
-          - toxenv: py36-dj20
-            python-version: 3.6
-          - toxenv: py36-dj21
-            python-version: 3.6
           - toxenv: py36-dj22
             python-version: 3.6
-          - toxenv: py37-dj21
-            python-version: 3.7
-          - toxenv: py37-dj22
-            python-version: 3.7
+          - toxenv: py36-dj30
+            python-version: 3.6
+          - toxenv: py38-dj111
+            python-version: 3.8
+          - toxenv: py38-dj22
+            python-version: 3.8
+          - toxenv: py38-dj30
+            python-version: 3.8
 
     steps:
       - uses: actions/checkout@v1

--- a/flags/tests/test_panels.py
+++ b/flags/tests/test_panels.py
@@ -1,3 +1,4 @@
+from django.http import HttpResponse
 from django.test import RequestFactory, TestCase, override_settings
 
 from debug_toolbar.toolbar import DebugToolbar
@@ -8,7 +9,8 @@ from flags.state import flag_state
 class FlagsPanelTestCase(TestCase):
     def setUp(self):
         self.request = RequestFactory().get("/")
-        self.toolbar = DebugToolbar(self.request)
+        self.get_response = lambda req: HttpResponse()
+        self.toolbar = DebugToolbar(self.request, self.get_response)
         self.toolbar.stats = {}
         self.panel = self.toolbar.get_panel_by_id("FlagsPanel")
 
@@ -33,7 +35,8 @@ class FlagsPanelTestCase(TestCase):
 class FlagChecksPanelTestCase(TestCase):
     def setUp(self):
         self.request = RequestFactory().get("/")
-        self.toolbar = DebugToolbar(self.request)
+        self.get_response = lambda req: HttpResponse()
+        self.toolbar = DebugToolbar(self.request, self.get_response)
         self.toolbar.stats = {}
         self.panel = self.toolbar.get_panel_by_id("FlagChecksPanel")
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = ["Django>=1.11,<3.1"]
 testing_extras = [
     "mock>=2.0.0",
     "coverage>=3.7.0",
-    "django-debug-toolbar>=1.11,<1.12",
+    "django-debug-toolbar>=1.11,<2.3",
     "jinja2",
 ]
 
@@ -34,16 +34,16 @@ setup(
     extras_require={"testing": testing_extras, "docs": docs_extras},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 1.11",
         "Framework :: Django :: 2.0",
         "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
+        "Framework :: Django :: 3.0",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "License :: Public Domain",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36}-dj{111},py{36,37}-dj{20,21,22}
+envlist=lint,py{36,38}-dj{111,22,30}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -13,13 +13,12 @@ setenv=
 
 basepython=
     py36: python3.6
-    py37: python3.7
+    py38: python3.8
 
 deps=
     dj111: Django>=1.11,<1.12
-    dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.2,<2.3
+    dj30: Django>=3.0,<3.1
 
 [testenv:lint]
 basepython=python3.6


### PR DESCRIPTION
This change adds support for Django 3.0. It requires updating the Django Rest Framework supported version range and dealing with the minor API changes that it brings with it.

This change also drops testing for non-LTS versions of Django 2.0. Those versions should be supported, but if you're using Django 2.x you should be on 2.2.