### PR TITLE
Remove unsupported django-debug-toolbar version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ install_requires = ["Django>=1.11,<3.1"]
 testing_extras = [
     "mock>=2.0.0",
     "coverage>=3.7.0",
-    "django-debug-toolbar>=1.11,<2.3",
+    "django-debug-toolbar>=2.0,<2.3",
     "jinja2",
 ]
 


### PR DESCRIPTION
#58 (f4007d5) relies on [an interface change](https://github.com/jazzband/django-debug-toolbar/commit/5299cf826284b6e082c5f18050e4f706faa81c39#diff-0caf32ffe5d678b291e3873eac4db0c6R21) in django-debug-toolbar that was introduced in version 2.0. Running the tests against previous version 1.11 fails because of this.