### PR TITLE
Raise MiddlewareNotUsed in deprecated FlagConditionsMiddleware

### DIFF
--- a/flags/middleware.py
+++ b/flags/middleware.py
@@ -1,5 +1,7 @@
 import warnings
 
+from django.core.exceptions import MiddlewareNotUsed
+
 
 class FlagConditionsMiddleware:
     def __init__(self, get_response):
@@ -8,6 +10,4 @@ class FlagConditionsMiddleware:
             "effect. It will be removed in a future version of Django-Flags. ",
             FutureWarning,
         )
-
-    def __call__(self, request):
-        pass
+        raise MiddlewareNotUsed

--- a/flags/tests/test_middleware.py
+++ b/flags/tests/test_middleware.py
@@ -1,5 +1,6 @@
 import warnings
 
+from django.core.exceptions import MiddlewareNotUsed
 from django.test import SimpleTestCase
 
 from flags.middleware import FlagConditionsMiddleware
@@ -8,7 +9,8 @@ from flags.middleware import FlagConditionsMiddleware
 class FlagConditionsMiddlewareTests(SimpleTestCase):
     def test_middleware_raises_warning(self):
         with warnings.catch_warnings(record=True) as warning_list:
-            FlagConditionsMiddleware(None)
+            with self.assertRaises(MiddlewareNotUsed):
+                FlagConditionsMiddleware(None)
 
             self.assertEqual(len(warning_list), 1)
             self.assertEqual(warning_list[0].category, FutureWarning)


### PR DESCRIPTION
Per the [Django documentation](https://docs.djangoproject.com/en/2.2/topics/http/middleware/#marking-middleware-as-unused) on marking middle as unused, this change raises `MiddlewareNotUsed` when initializing the deprecated `FlagConditionsMiddleware`. This way, Django takes the middleware out of the middleware process and the fact that this middleware no longer calls `get_response` and returns it for a request will not interrupt the flow of the request through other middleware or to the user.

This allows us to get rid of the `__call__` noop.