### PR TITLE
Remove Django 1.11 support and cleanup for 5.0.0 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,21 +32,15 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj111
             - py36-dj22
             - py36-dj30
-            - py38-dj111
             - py38-dj22
             - py38-dj30
         include:
-          - toxenv: py36-dj111
-            python-version: 3.6
           - toxenv: py36-dj22
             python-version: 3.6
           - toxenv: py36-dj30
             python-version: 3.6
-          - toxenv: py38-dj111
-            python-version: 3.8
           - toxenv: py38-dj22
             python-version: 3.8
           - toxenv: py38-dj30

--- a/docs/api/urls.md
+++ b/docs/api/urls.md
@@ -2,8 +2,6 @@
 
 Flagged URL patterns are an alternative to [flagging views with decorators](../../api/decorators).
 
-## Django 2.0+
-
 ```python
 from flags.urls import flagged_path, flagged_paths, flagged_re_path, flagged_re_paths
 ```
@@ -52,55 +50,6 @@ Flag multiple URLs in the same context with a context manager.
 with flagged_paths('MY_FLAG') as path:
     flagged_url_patterns = [
         path('a-url/', view_requiring_flag),
-    ]
-
-urlpatterns = urlpatterns + flagged_url_patterns
-```
-
-## Django 1.x
-
-```python
-from flags.urls import flagged_url, flagged_urls
-```
-
-### `flagged_url(flag_name, regex, view, kwargs=None, name=None, state=True, fallback=None)`
-
-Make a URL depend on the state of a feature flag. 
-
-`flagged_url()` can be used in place of [Django's `url()`](https://docs.djangoproject.com/en/1.11/ref/urls/#django.conf.urls.url).
-
-The `view` and the `fallback` can both be a set of `include()`ed patterns but any matching URL patterns in the includes must match *exactly* in terms of regular expression, keyword arguments, and name, otherwise a `404` may be unexpectedly raised. 
-
-If a `fallback` is not given the flagged url will raise a `404` if the flag state does not match the required `state`. 
-
-!!! note
-    When a fallback view is given it *must* take the same arguments as the flagged view.
-
-```python
-urlpatterns = [
-    flagged_url('MY_FLAG', r'a-url/', view_requiring_flag, state=True),
-    flagged_url('MY_FLAG_WITH_FALLBACK', r'^another-url$', 
-                view_with_fallback, state=True, fallback=other_view)
-    flagged_url('MY_FLAGGED_INCLUDE', '^myapp/', include('myapp.urls'),
-                state=True, fallback=other_view)
-    flagged_url('MY_NEW_APP_FLAG', r'^mynewapp$', include('mynewapp.urls'),
-                state=True, fallback=include('myoldapp.urls'))
-]
-```
-
-### `flagged_urls(flag_name, state=True, fallback=None)`
-
-Flag multiple URLs in the same context with a context manager.
-
-`flagged_urls()` returns a function that takes the same arguments as [Django's `url()`](https://docs.djangoproject.com/en/1.11/ref/urls/#django.conf.urls.url).
-
-!!! note
-    When a fallback view is given it *must* take the same arguments as the flagged view.
-
-```python
-with flagged_urls('MY_FLAG') as furl:
-    flagged_url_patterns = [
-        furl(^'a-url/', view_requiring_flag),
     ]
 
 urlpatterns = urlpatterns + flagged_url_patterns

--- a/docs/api/views.md
+++ b/docs/api/views.md
@@ -51,17 +51,6 @@ urlpatterns = [
 ]
 ```
 
-#### Django 1.x
-
-```python
-from django.urls import path
-from flags.urls import flagged_path
-
-urlpatterns = [
-    url(r'^my-url/$', MyFlaggedView.as_view(flag_name='MY_FLAG'))
-]
-```
-
 ### `FlaggedTemplateView`
 
 A combination of [`TemplateView`](https://docs.djangoproject.com/en/2.2/ref/class-based-views/base/#templateview) and [`FlaggedViewMixin`](#flaggedviewmixin).
@@ -85,23 +74,6 @@ from flags.views import FlaggedTemplateView
 urlpatterns = [
     path(
         'my_url/', 
-        FlaggedTemplateView.as_view(
-            template_name='mytemplate.html', 
-            flag_name='MY_FLAG'
-        )
-    ),
-]
-```
-
-#### Django 1.x
-
-```
-from django.urls import url
-from flags.views import FlaggedTemplateView
-
-urlpatterns = [
-    url(
-        r'^my_url/$', 
         FlaggedTemplateView.as_view(
             template_name='mytemplate.html', 
             flag_name='MY_FLAG'

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Feature flags allow you to toggle functionality in both Django code and the Djan
 
 ## Dependencies
 
-- Django 1.11+ (including Django 2)
+- Django 2.2, 3.0
 - Python 3.6+
 
 ## Installation
@@ -85,25 +85,12 @@ Then use the flag in a Django template (`mytemplate.html`):
 
 Configure a URL for that template (`urls.py`):
 
-Django 2.0:
-
 ```python
 from django.urls import path
 from django.views.generic import TemplateView
 
 urlpatterns = [
     path(r'mypage/', TemplateView.as_view(template_name='mytemplate.html')),
-]
-```
-
-Django 1.x:
-
-```python
-from django.conf.urls import url
-from django.views.generic import TemplateView
-
-urlpatterns = [
-    url(r'^mypage/$', TemplateView.as_view(template_name='mytemplate.html')),
 ]
 ```
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Unreleased
+## 5.0.0
 
 ### What's new?
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -9,11 +9,12 @@
 
 ### Deprecations
 
- - Deprecated the optional `flags.middleware.FlagConditionsMiddleware` in favor of always lazily caching flags on the request object.
+- Deprecated the optional `flags.middleware.FlagConditionsMiddleware` in favor of always lazily caching flags on the request object.
 
 ### Removals
 
- - Django Flags 4.1 deprecated support for using a single dictionary to hold key/values of conditions for a settings-based feature flag, and this has been removed. Use [a list of dictionaries or tuples instead](/settings/#flags).
+- Django Flags 4.1 deprecated support for using a single dictionary to hold key/values of conditions for a settings-based feature flag, and this has been removed. Use [a list of dictionaries or tuples instead](/settings/#flags).
+- Removed support for Django 1.11.
 
 
 ## 4.2.4

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -6,7 +6,15 @@
 
 - Added Django 3.0 support
 - Added validator support to ensure that the values that flag conditions test against are valid.
-- Deprecated the optional `flags.middleware.FlagConditionsMiddleware` in favor of always lazily caching flags on the request object.
+
+### Deprecations
+
+ - Deprecated the optional `flags.middleware.FlagConditionsMiddleware` in favor of always lazily caching flags on the request object.
+
+### Removals
+
+ - Django Flags 4.1 deprecated support for using a single dictionary to hold key/values of conditions for a settings-based feature flag, and this has been removed. Use [a list of dictionaries or tuples instead](/settings/#flags).
+
 
 ## 4.2.4
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -33,7 +33,7 @@ if flag_enabled('FLAG_WITH_ANY_CONDITIONS', request=a_request):
     print("My feature flag is enabled")	
 ```
 
-Django templates:
+In Django templates:
 
 ```django
 {% load feature_flags %}
@@ -45,7 +45,7 @@ Django templates:
 {% endif %}
 ```
 
-Jinja2 templates (after [adding `flag_enabled` to the Jinja2 environment](../api/jinja2/)):
+In Jinja2 templates (after [adding `flag_enabled` to the Jinja2 environment](../api/jinja2/)):
 
 ```jinja
 {% if flag_enabled('FLAG_WITH_ANY_CONDITIONS', request) %}
@@ -55,23 +55,13 @@ Jinja2 templates (after [adding `flag_enabled` to the Jinja2 environment](../api
 {% endif %}
 ```
 
-Django 2.0 `urls.py`:
+In `urls.py`:
 
 ```python
 from flags.urls import flagged_path
 
 urlpatterns = [
     flagged_path('FLAG_WITH_REQUIRED_CONDITIONS', 'a-url/', view_requiring_flag, state=True),
-]
-```
-
-And Django 1.x `urls.py`:
-
-```python
-from flags.urls import flagged_url
-
-urlpatterns = [
-    flagged_url('FLAG_WITH_REQUIRED_CONDITIONS', r'^a-url$', view_requiring_flag, state=True),
 ]
 ```
 

--- a/flags/conditions/conditions.py
+++ b/flags/conditions/conditions.py
@@ -1,7 +1,6 @@
 import re
 from distutils.util import strtobool
 
-import django
 from django.contrib.auth import get_user_model
 from django.utils import dateparse, timezone
 
@@ -46,10 +45,7 @@ def anonymous_condition(boolean_value, request=None, **kwargs):
             "request is required for condition 'anonymous'"
         )
 
-    if django.VERSION[0] >= 2:  # pragma: no cover
-        is_anonymous = bool(request.user.is_anonymous)
-    else:  # pragma: no cover
-        is_anonymous = bool(request.user.is_anonymous())
+    is_anonymous = bool(request.user.is_anonymous)
 
     try:
         return strtobool(boolean_value.strip().lower()) == is_anonymous

--- a/flags/sources.py
+++ b/flags/sources.py
@@ -89,16 +89,6 @@ class SettingsFlagsSource(object):
         settings_flags = getattr(settings, "FLAGS", {}).items()
         flags = {}
         for flag, conditions in settings_flags:
-            # Flag conditions in settings used to be dicts, which are now
-            # deprecated.
-            if isinstance(conditions, dict):
-                warnings.warn(
-                    "dict feature flag definitions are deprecated and will be "
-                    "removed in a future version of Django-Flags. "
-                    "Please use a list of dicts or tuples instead.",
-                    FutureWarning,
-                )
-                conditions = conditions.items()
 
             # Flag conditions should be a list of either 3-tuples of
             # dictionaries in the form (condition, value, required) or

--- a/flags/sources.py
+++ b/flags/sources.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 from django.apps import apps
 from django.conf import settings

--- a/flags/templatetags/feature_flags.py
+++ b/flags/templatetags/feature_flags.py
@@ -1,4 +1,3 @@
-import django
 from django import template
 
 from flags.state import (
@@ -9,25 +8,20 @@ from flags.state import (
 
 register = template.Library()
 
-if django.VERSION >= (1, 9):  # pragma: no cover
-    simple_tag = register.simple_tag
-else:  # pragma: no cover
-    simple_tag = register.assignment_tag
-
 
 # Creates template tags flag_enabled and flag_disabled that call
 # base_flag_enabled and base_flag_disabled, passing in any arguments, including
 # the request (which could be passed explicitly, or pulled from the context).
 
 
-@simple_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def flag_enabled(context, flag_name, request=None, **kwargs):
     if request is None:
         request = context.get("request")
     return base_flag_enabled(flag_name, request=request, **kwargs)
 
 
-@simple_tag(takes_context=True)
+@register.simple_tag(takes_context=True)
 def flag_disabled(context, flag_name, request=None, **kwargs):
     if request is None:
         request = context.get("request")

--- a/flags/tests/settings.py
+++ b/flags/tests/settings.py
@@ -1,7 +1,5 @@
 import os
 
-import django
-
 from flags.conditions import register
 
 
@@ -32,18 +30,12 @@ INSTALLED_APPS = (
 
 INSTALLED_APPS += ("flags", "flags.tests.testapp")
 
-if django.VERSION >= (1, 10):  # pragma: no cover
-    MIDDLEWARE = (
-        "debug_toolbar.middleware.DebugToolbarMiddleware",
-        "django.contrib.sessions.middleware.SessionMiddleware",
-        "django.contrib.auth.middleware.AuthenticationMiddleware",
-        "django.contrib.messages.middleware.MessageMiddleware",
-    )
-else:  # pragma: no cover
-    MIDDLEWARE_CLASSES = (
-        "django.contrib.sessions.middleware.SessionMiddleware",
-        "django.contrib.auth.middleware.AuthenticationMiddleware",
-    )
+MIDDLEWARE = (
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+)
 
 TEMPLATES = [
     {

--- a/flags/tests/test_admin.py
+++ b/flags/tests/test_admin.py
@@ -1,12 +1,7 @@
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.test import Client, TestCase, override_settings
-
-
-try:
-    from django.urls import re_path
-except ImportError:  # pragma: no cover
-    from django.conf.urls import url as re_path
+from django.urls import re_path
 
 
 urlpatterns = [

--- a/flags/tests/test_decorators.py
+++ b/flags/tests/test_decorators.py
@@ -1,15 +1,10 @@
 import warnings
+from unittest.mock import Mock
 
 from django.http import Http404, HttpRequest, HttpResponse
 from django.test import TestCase
 
 from flags.decorators import flag_check, flag_required
-
-
-try:
-    from unittest.mock import Mock
-except ImportError:  # pragma: no cover
-    from mock import Mock
 
 
 class FlagCheckTestCase(TestCase):

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -1,4 +1,3 @@
-import warnings
 
 from django.http import HttpRequest
 from django.test import TestCase, override_settings

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -34,19 +34,6 @@ class ExceptionalFlagsSource(object):
 
 
 class SettingsFlagsSourceTestCase(TestCase):
-    @override_settings(FLAGS={"MY_FLAG": {"boolean": True}})
-    def test_get_flags_dict(self):
-        source = SettingsFlagsSource()
-        with warnings.catch_warnings(record=True) as warning_list:
-            flags = source.get_flags()
-            self.assertTrue(
-                any(item.category == FutureWarning for item in warning_list)
-            )
-
-        self.assertEqual(
-            flags, {"MY_FLAG": [Condition("boolean", True, required=False)]},
-        )
-
     @override_settings(FLAGS={"MY_FLAG": [("boolean", True)]})
     def test_get_flags_two_tuple(self):
         source = SettingsFlagsSource()

--- a/flags/tests/test_sources.py
+++ b/flags/tests/test_sources.py
@@ -1,3 +1,4 @@
+from unittest.mock import Mock
 
 from django.http import HttpRequest
 from django.test import TestCase, override_settings
@@ -10,12 +11,6 @@ from flags.sources import (
     SettingsFlagsSource,
     get_flags,
 )
-
-
-try:
-    from unittest.mock import Mock
-except ImportError:  # pragma: no cover
-    from mock import Mock
 
 
 # Test flag source for using this module to test

--- a/flags/tests/test_state.py
+++ b/flags/tests/test_state.py
@@ -1,13 +1,9 @@
+from unittest import mock
+
 from django.core.exceptions import AppRegistryNotReady
 from django.test import RequestFactory, TestCase
 
 from flags.state import flag_disabled, flag_enabled, flag_state
-
-
-try:
-    from unittest import mock
-except ImportError:  # pragma: no cover
-    import mock
 
 
 class FlagStateTestCase(TestCase):

--- a/flags/tests/test_urls.py
+++ b/flags/tests/test_urls.py
@@ -2,23 +2,9 @@ from unittest import skipIf
 
 from django.http import Http404, HttpResponse
 from django.test import RequestFactory, TestCase, override_settings
+from django.urls import include, path, re_path, resolve
 
-
-try:
-    from django.urls import include, path, resolve, re_path
-except ImportError:  # pragma: no cover
-    from django.core.urlresolvers import resolve
-    from django.conf.urls import include, url as re_path
-
-    path = None
-
-try:
-    from flags.urls import flagged_path, flagged_re_path, flagged_re_paths
-except ImportError:  # pragma: no cover
-    from flags.urls import (
-        flagged_url as flagged_re_path,
-        flagged_urls as flagged_re_paths,
-    )
+from flags.urls import flagged_path, flagged_re_path, flagged_re_paths
 
 
 def view(request):
@@ -119,17 +105,16 @@ with flagged_re_paths("FLAGGED_URL", fallback=fallback) as re_path:
     ]
 urlpatterns = urlpatterns + flagged_patterns_true_fallback
 
-if path:  # pragma: no cover
-    path_patterns = [
-        flagged_path(
-            "FLAGGED_URL",
-            "path-true-no-fallback",
-            view,
-            name="some-view",
-            state=True,
-        ),
-    ]
-    urlpatterns = urlpatterns + path_patterns
+path_patterns = [
+    flagged_path(
+        "FLAGGED_URL",
+        "path-true-no-fallback",
+        view,
+        name="some-view",
+        state=True,
+    ),
+]
+urlpatterns = urlpatterns + path_patterns
 
 
 @override_settings(ROOT_URLCONF=__name__,)

--- a/setup.py
+++ b/setup.py
@@ -33,8 +33,6 @@ setup(
     extras_require={"testing": testing_extras, "docs": docs_extras},
     classifiers=[
         "Framework :: Django",
-        "Framework :: Django :: 2.0",
-        "Framework :: Django :: 2.1",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ long_description = open("README.md", "r").read()
 install_requires = ["Django>=1.11,<3.1"]
 
 testing_extras = [
-    "mock>=2.0.0",
     "coverage>=3.7.0",
     "django-debug-toolbar>=2.0,<2.3",
     "jinja2",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     license="CC0",
-    version="4.2.4",
+    version="5.0.0",
     include_package_data=True,
     packages=find_packages(),
     install_requires=install_requires,

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36,38}-dj{111,22,30}
+envlist=lint,py{36,38}-dj{22,30}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -16,7 +16,6 @@ basepython=
     py38: python3.8
 
 deps=
-    dj111: Django>=1.11,<1.12
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
 
@@ -24,8 +23,8 @@ deps=
 basepython=python3.6
 deps=
     black
-    flake8>=2.2.0
-    isort>=4.2.15
+    flake8
+    isort
 commands=
     black --check flags setup.py
     flake8 flags setup.py


### PR DESCRIPTION
This PR does some cleanup for our 5.0.0 release. This includes removing Django 1.11 support and removing support for single-dictionary key/value flag definitions in settings that was deprecated in 4.1. I've also removed the dependency on `mock` in favor of `unittest.mock`.