### PR TITLE
Updates to support isort 5.0

### DIFF
--- a/flags/jinja2tags.py
+++ b/flags/jinja2tags.py
@@ -1,6 +1,7 @@
-from flags.templatetags.feature_flags import flag_disabled, flag_enabled
 from jinja2 import contextfunction
 from jinja2.ext import Extension
+
+from flags.templatetags.feature_flags import flag_disabled, flag_enabled
 
 
 class FlagsExtension(Extension):

--- a/flags/panels.py
+++ b/flags/panels.py
@@ -3,6 +3,7 @@ import logging
 from django.utils.translation import gettext_lazy as _
 
 from debug_toolbar.panels import Panel
+
 from flags import state
 from flags.sources import get_flags
 

--- a/flags/state.py
+++ b/flags/state.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from django.apps import apps
 from django.core.exceptions import AppRegistryNotReady
 

--- a/flags/tests/test_panels.py
+++ b/flags/tests/test_panels.py
@@ -2,6 +2,7 @@ from django.http import HttpResponse
 from django.test import RequestFactory, TestCase, override_settings
 
 from debug_toolbar.toolbar import DebugToolbar
+
 from flags.state import flag_state
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,6 @@
 from setuptools import find_packages, setup
 
 
-long_description = open("README.md", "r").read()
-
 install_requires = ["Django>=1.11,<3.1"]
 
 testing_extras = [
@@ -23,12 +21,13 @@ setup(
     author="CFPB",
     author_email="tech@cfpb.gov",
     description="Feature flags for Django projects",
-    long_description=long_description,
+    long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     license="CC0",
     version="5.0.0",
     include_package_data=True,
     packages=find_packages(),
+    python_requires=">=3.8",
     install_requires=install_requires,
     extras_require={"testing": testing_extras, "docs": docs_extras},
     classifiers=[
@@ -39,8 +38,5 @@ setup(
         "License :: Public Domain",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     version="5.0.0",
     include_package_data=True,
     packages=find_packages(),
-    python_requires=">=3.8",
+    python_requires=">=3.6",
     install_requires=install_requires,
     extras_require={"testing": testing_extras, "docs": docs_extras},
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ deps=
 commands=
     black --check flags setup.py
     flake8 flags setup.py
-    isort --check-only --diff --recursive flags
+    isort --check-only --diff flags
 
 [testenv:docs]
 basepython=python3.6
@@ -52,7 +52,6 @@ lines_after_imports=2
 include_trailing_comma=1
 multi_line_output=3
 skip=.tox,migrations
-not_skip=__init__.py
 use_parentheses=1
 known_django=django
 known_future_library=future,six

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,6 @@ multi_line_output=3
 skip=.tox,migrations
 use_parentheses=1
 known_django=django
-known_future_library=future,six
+known_future_library=future
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER

--- a/tox.ini
+++ b/tox.ini
@@ -54,6 +54,5 @@ multi_line_output=3
 skip=.tox,migrations
 use_parentheses=1
 known_django=django
-known_future_library=future
 default_section=THIRDPARTY
 sections=FUTURE,STDLIB,DJANGO,THIRDPARTY,FIRSTPARTY,LOCALFOLDER


### PR DESCRIPTION
Removed `not_skip` and `recursive` from `tox.ini` to fix
TypeError: __init__() got an unexpected keyword argument 'not_skip'

## recursive
Prior to version 5.0.0, isort wouldn't automatically traverse directories. The --recursive option was necessary to tell it to do so. In 5.0.0 directories are automatically traversed for all Python files, and as such this option is no longer necessary and should simply be removed.

## not_skip
In an earlier version isort had a default skip of __init__.py. To get around that many projects wanted a way to not skip __init__.py or any other files that were automatically skipped in the future by isort. isort no longer has any default skips, so if the value here is __init__.py you can simply remove the setting.

https://timothycrosley.github.io/isort/docs/upgrade_guides/5.0.0/

Short description explaining the high-level reason for the pull request

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests