### PR TITLE
Add support for Django 3.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,16 +34,22 @@ jobs:
         toxenv:
             - py36-dj22
             - py36-dj30
+            - py36-dj31
             - py38-dj22
             - py38-dj30
+            - py38-dj31
         include:
           - toxenv: py36-dj22
             python-version: 3.6
           - toxenv: py36-dj30
             python-version: 3.6
+          - toxenv: py36-dj31
+            python-version: 3.6
           - toxenv: py38-dj22
             python-version: 3.8
           - toxenv: py38-dj30
+            python-version: 3.8
+          - toxenv: py38-dj31
             python-version: 3.8
 
     steps:

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Feature flags allow you to toggle functionality in both Django code and the Djan
 ## Dependencies
 
 - Python 3.6+
-- Django 2.2, 3.0
+- Django 2.2-3.1
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 
-install_requires = ["Django>=1.11,<3.1"]
+install_requires = ["Django>=1.11,<3.2"]
 
 testing_extras = [
     "coverage>=3.7.0",
@@ -24,7 +24,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="5.0.0",
+    version="5.0.1",
     include_package_data=True,
     packages=find_packages(),
     python_requires=">=3.6",
@@ -34,6 +34,7 @@ setup(
         "Framework :: Django",
         "Framework :: Django :: 2.2",
         "Framework :: Django :: 3.0",
+        "Framework :: Django :: 3.1",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "License :: Public Domain",
         "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36,38}-dj{22,30}
+envlist=lint,py{36,38}-dj{22,30,31}
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -18,6 +18,7 @@ basepython=
 deps=
     dj22: Django>=2.2,<2.3
     dj30: Django>=3.0,<3.1
+    dj31: Django>=3.1,<3.2
 
 [testenv:lint]
 basepython=python3.6


### PR DESCRIPTION
This PR adds support for testing against Django 3.1 and updates the README and `setup.py` to include Django 3.1 in the supported version range.