### PR TITLE
Validate "path matches" conditions as regular expressions

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Unreleased
+
+### What's new?
+
+- Fixed the "path matches" condition validator to allow any valid regular expression.
+
+
 ## 5.0.3
 
 ### What's new?

--- a/flags/conditions/__init__.py
+++ b/flags/conditions/__init__.py
@@ -20,6 +20,6 @@ from flags.conditions.validators import (
     validate_boolean,
     validate_date,
     validate_parameter,
-    validate_path,
+    validate_path_re,
     validate_user,
 )

--- a/flags/conditions/conditions.py
+++ b/flags/conditions/conditions.py
@@ -9,7 +9,7 @@ from flags.conditions.validators import (
     validate_boolean,
     validate_date,
     validate_parameter,
-    validate_path,
+    validate_path_re,
     validate_user,
 )
 
@@ -67,7 +67,7 @@ def parameter_condition(param_name, request=None, **kwargs):
     return request.GET.get(param_name) == param_value
 
 
-@register("path matches", validator=validate_path)
+@register("path matches", validator=validate_path_re)
 def path_condition(pattern, request=None, **kwargs):
     """ Does the request's path match the given regular expression? """
     if request is None:

--- a/flags/conditions/validators.py
+++ b/flags/conditions/validators.py
@@ -7,20 +7,21 @@ from django.core.validators import RegexValidator
 from django.utils import dateparse
 
 
-validate_path = RegexValidator(
-    re.compile(r"^[^\s:?#]+$", re.UNICODE),
-    message=(
-        "Enter a valid path without a URL scheme, query string, or fragment."
-    ),
-    code="invalid",
-)
-
-
 validate_parameter = RegexValidator(
     re.compile(r"^[-_\w=]+$", re.UNICODE),
     message="Enter a valid HTTP parameter name.",
     code="invalid",
 )
+
+
+def validate_path_re(value):
+    try:
+        re.compile(value)
+    except re.error as e:
+        raise ValidationError(
+            "Enter either a valid path or a regular expression to match a "
+            "path, without a URL scheme, query string, or fragment."
+        ) from e
 
 
 def validate_boolean(value):

--- a/flags/tests/test_conditions_validators.py
+++ b/flags/tests/test_conditions_validators.py
@@ -6,7 +6,7 @@ from flags.conditions.validators import (
     validate_boolean,
     validate_date,
     validate_parameter,
-    validate_path,
+    validate_path_re,
     validate_user,
 )
 
@@ -26,18 +26,15 @@ class ValidateParameterTestCase(TestCase):
 
 
 class ValidatePathTestCase(TestCase):
-    def test_invalid_path_strings(self):
+    def test_invalid_path_regexs(self):
         with self.assertRaises(ValidationError):
-            validate_path("/my/path#foo")
-        with self.assertRaises(ValidationError):
-            validate_path("/my/path?foo=bar")
-        with self.assertRaises(ValidationError):
-            validate_path("https://foo/my/path")
+            validate_path_re("*foo/my/path")
 
-    def test_valid_path_strings(self):
-        validate_path("/my/path")
-        validate_path("/my/path/")
-        validate_path("my/path/")
+    def test_valid_path_regexs(self):
+        validate_path_re("/my/path")
+        validate_path_re("/my/path/")
+        validate_path_re("my/path/")
+        validate_path_re(r"^/my/(path)?$")
 
 
 class ValidateBooleanTestCase(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps=
     dj31: Django>=3.1,<3.2
 
 [testenv:lint]
-basepython=python3.6
+basepython=python3.8
 deps=
     black
     flake8


### PR DESCRIPTION
Because "path matches" conditions can be any valid regular expression, this change simply uses `re.compile()` to validate them.

Previously they were validated as URL paths, without querystring or URL scheme-matching characters allowed. This warned on some valid regular expressions that it shouldn't have.

This fix is what @chosak suggested in, and fixes #77.