### PR TITLE
Add Django 4.0 support and update to test against Python 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,18 +34,23 @@ jobs:
         toxenv:
             - py36-dj22
             - py36-dj32
+            - py36-dj40
             - py38-dj22
             - py38-dj32
+            - py38-dj40
         include:
           - toxenv: py36-dj22
             python-version: 3.6
           - toxenv: py36-dj32
             python-version: 3.6
+          - toxenv: py36-dj40
+            python-version: 3.6
           - toxenv: py38-dj22
             python-version: 3.8
           - toxenv: py38-dj32
             python-version: 3.8
-
+          - toxenv: py38-dj40
+            python-version: 3.8
     steps:
       - uses: actions/checkout@v1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install dependencies
         run: |
@@ -45,7 +45,7 @@ jobs:
           - toxenv: py39-dj22
             python-version: 3.9
           - toxenv: py39-dj32
-            python-version: 3.8
+            python-version: 3.9
           - toxenv: py39-dj40
             python-version: 3.9
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install tox
-  
+
       - name: Run tox -e lint
         run: tox
-        env: 
+        env:
           TOXENV: lint
 
   test:
@@ -34,23 +34,20 @@ jobs:
         toxenv:
             - py36-dj22
             - py36-dj32
-            - py36-dj40
-            - py38-dj22
-            - py38-dj32
-            - py38-dj40
+            - py39-dj22
+            - py39-dj32
+            - py39-dj40
         include:
           - toxenv: py36-dj22
             python-version: 3.6
           - toxenv: py36-dj32
             python-version: 3.6
-          - toxenv: py36-dj40
-            python-version: 3.6
-          - toxenv: py38-dj22
+          - toxenv: py39-dj22
+            python-version: 3.9
+          - toxenv: py39-dj32
             python-version: 3.8
-          - toxenv: py38-dj32
-            python-version: 3.8
-          - toxenv: py38-dj40
-            python-version: 3.8
+          - toxenv: py39-dj40
+            python-version: 3.9
     steps:
       - uses: actions/checkout@v1
 
@@ -68,7 +65,7 @@ jobs:
         run: |
             tox
             coveralls
-        env: 
+        env:
           TOXENV: ${{ matrix.toxenv }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -6,19 +6,18 @@
 
 Feature flags allow you to toggle functionality in both Django code and the Django templates based on configurable conditions. Flags can be useful for staging feature deployments, for A/B testing, or for any time you need an on/off switch for blocks of code. The toggle can be by date, user, URL value, or a number of [other conditions](https://cfpb.github.io/django-flags/conditions/), editable in the admin or in definable in settings.
 
-- [Django-Flags](#django-flags)
-  - [Dependencies](#dependencies)
-  - [Installation](#installation)
-  - [Documentation](#documentation)
-  - [Getting help](#getting-help)
-  - [Getting involved](#getting-involved)
-  - [Licensing](#licensing)
-  - [Credits and references](#credits-and-references)
+- [Dependencies](#dependencies)
+- [Installation](#installation)
+- [Documentation](#documentation)
+- [Getting help](#getting-help)
+- [Getting involved](#getting-involved)
+- [Licensing](#licensing)
+- [Credits and references](#credits-and-references)
 
 ## Dependencies
 
 - Python 3.6+
-- Django 2.2-4
+- Django 2.2-4.0
 
 ## Installation
 
@@ -40,7 +39,7 @@ pip install django-flags
 
 ## Documentation
 
-https://cfpb.github.io/django-flags is the full documentation for Django-Flags, and includes how to get started, general usage, and an API reference. 
+https://cfpb.github.io/django-flags is the full documentation for Django-Flags, and includes how to get started, general usage, and an API reference.
 
 ## Getting help
 

--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@
 
 Feature flags allow you to toggle functionality in both Django code and the Django templates based on configurable conditions. Flags can be useful for staging feature deployments, for A/B testing, or for any time you need an on/off switch for blocks of code. The toggle can be by date, user, URL value, or a number of [other conditions](https://cfpb.github.io/django-flags/conditions/), editable in the admin or in definable in settings.
 
-- [Dependencies](#dependencies)
-- [Installation](#installation)
-- [Documentation](#documentation)
-- [Getting help](#getting-help)
-- [Getting involved](#getting-involved)
-- [Licensing](#licensing)
-- [Credits and references](#credits-and-references)
+- [Django-Flags](#django-flags)
+  - [Dependencies](#dependencies)
+  - [Installation](#installation)
+  - [Documentation](#documentation)
+  - [Getting help](#getting-help)
+  - [Getting involved](#getting-involved)
+  - [Licensing](#licensing)
+  - [Credits and references](#credits-and-references)
 
 ## Dependencies
 
 - Python 3.6+
-- Django 2.2-3.2
+- Django 2.2-4
 
 ## Installation
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 5.0.6
+
+### What's new?
+
+- Added Django 4.0 support (thanks [@gregtap](https://github.com/gregtap)!)
+
+
 ## 5.0.5
 
 ### What's new?
@@ -131,7 +138,7 @@
 ### What's new?
 
 - The template functions `flag_enabled` and `flag_disabled` in both [Django](/api/django) and [Jinja2](/api/jinja2) templates now support taking keyword arguments that could be used by [custom conditions](/api/conditions).
-- Jinja2 template functions are now available via a Jinja2 extension that can be [included in `settings.py`](/api/jinja2). 
+- Jinja2 template functions are now available via a Jinja2 extension that can be [included in `settings.py`](/api/jinja2).
 - The optional `flags.middleware.FlagConditionsMiddleware` has been added to ensure that all feature flag checks throughout single request cycle use the same flag conditions.
 - Support for specifying the [source of feature flags in `settings.py`](/settings#flag_sources) has been added to allow further customization and the potential to limit flags to settings or database-only.
 - The "user" condition now supports custom user models. ([@callorico](https://github.com/callorico))
@@ -157,7 +164,7 @@ TEMPLATES = [
             ],
         }
     },
-] 
+]
 ```
 
 ## 3.0.2

--- a/flags/state.py
+++ b/flags/state.py
@@ -1,7 +1,6 @@
 from django.apps import apps
 from django.core.exceptions import AppRegistryNotReady
 
-from flags.models import FlagState
 from flags.sources import get_flags
 
 
@@ -20,6 +19,8 @@ def _set_flag_state(
     flag_name, state, create_boolean_condition=True, request=None
 ):
     """A private function to set a boolean condition to the desired state"""
+    from flags.models import FlagState
+
     flags = get_flags(request=request)
     flag = flags.get(flag_name)
     if flag is None:

--- a/flags/tests/test_conditions_validators.py
+++ b/flags/tests/test_conditions_validators.py
@@ -1,3 +1,4 @@
+import django
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
@@ -87,8 +88,13 @@ class ValidateDateTestCase(TestCase):
     def test_invalid_date_strings(self):
         with self.assertRaises(ValidationError):
             validate_date("tomorrowish")
-        with self.assertRaises(ValidationError):
-            validate_date("2020-04-01")
+
+        # Django 4.0 relies on Python 3.7+'s `datetime.fromisoformat()`, which
+        # handles this where the old regex did not. This is now valid when on
+        # Django 4.0+. See https://github.com/django/django/pull/14582
+        if django.VERSION < (4, 0):
+            with self.assertRaises(ValidationError):
+                validate_date("2020-04-01")
 
     def test_valid_date_strings(self):
         validate_date("2020-04-01T12:00")

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ install_requires = ["Django>=1.11,<=4"]
 
 testing_extras = [
     "coverage>=3.7.0",
-    "django-debug-toolbar>=2.0,<2.3",
+    "django-debug-toolbar>=3.2,<4",
     "jinja2",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     license="CC0",
-    version="5.0.5",
+    version="5.0.6",
     include_package_data=True,
     packages=find_packages(),
     python_requires=">=3.6",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 
-install_requires = ["Django>=1.11,<3.3"]
+install_requires = ["Django>=1.11,<=4"]
 
 testing_extras = [
     "coverage>=3.7.0",

--- a/tox.ini
+++ b/tox.ini
@@ -1,27 +1,27 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36,38}-dj{22,32}
+envlist=lint,py{36,39}-dj{22,32},py39-dj40
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
     coverage erase
-    coverage run --source='flags' {envbindir}/django-admin.py test {posargs}
+    coverage run --source='flags' {envbindir}/django-admin test {posargs}
     coverage report -m
 setenv=
     DJANGO_SETTINGS_MODULE=flags.tests.settings
 
 basepython=
     py36: python3.6
-    py38: python3.8
+    py39: python3.9
 
 deps=
     dj22: Django>=2.2,<2.3
     dj32: Django>=3.2,<3.3
-    dj40: Django==4
+    dj40: Django>=4.0,<4.1
 
 [testenv:lint]
-basepython=python3.8
+basepython=python3.9
 deps=
     black
     flake8

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ basepython=
 deps=
     dj22: Django>=2.2,<2.3
     dj32: Django>=3.2,<3.3
+    dj40: Django==4
 
 [testenv:lint]
 basepython=python3.8


### PR DESCRIPTION
This PR brings in @gregtap's changes from #87, makes sure the tests pass, and updates our preferred Python to test against to 3.9.