### PR TITLE
Update Django 4 pin to allow versions under 4.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 
-install_requires = ["Django>=1.11,<=4"]
+install_requires = ["Django>=1.11,<4.1"]
 
 testing_extras = [
     "coverage>=3.7.0",


### PR DESCRIPTION
Fixes #89.