### PR TITLE
Prevent RemovedInDjango41Warning

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Pending release
+
+### What's new?
+
+- Prevent `RemovedInDjango41Warning` about `default_app_config` for Django 3.2+.
+
 ## 5.0.7
 
 ### What's new?

--- a/flags/__init__.py
+++ b/flags/__init__.py
@@ -1,1 +1,5 @@
-default_app_config = "flags.apps.DjangoFlagsConfig"
+import django
+
+
+if django.VERSION < (3, 2):
+    default_app_config = "flags.apps.DjangoFlagsConfig"


### PR DESCRIPTION
Django 3.2 raises this warning:

```
/.../django/apps/registry.py:91: RemovedInDjango41Warning: 'flags' defines default_app_config = 'flags.apps.DjangoFlagsConfig'. Django now detects this configuration automatically. You can remove default_app_config.
  app_config = AppConfig.create(entry)
```

This PR changes the `default_app_config` definition to be gated to Django < 3.2. This is the same solution as I’ve implemented in my packages e.g. https://github.com/adamchainz/django-linear-migrations/blob/bf8233983a408fb8366f004b0def374d9b65b01f/src/django_linear_migrations/__init__.py .