### PR TITLE
Drop Coveralls in favor of coverage reported in GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,10 +8,10 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: 3.9
 
@@ -49,23 +49,55 @@ jobs:
           - toxenv: py39-dj40
             python-version: 3.9
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
 
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox coveralls
+          pip install tox
 
       - name: Run tox
-        run: |
-            tox
-            coveralls
+        run: tox
         env:
           TOXENV: ${{ matrix.toxenv }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Store test coverage
+        if: matrix.toxenv != 'lint'
+        uses: actions/upload-artifact@v2
+        with:
+          name: coverage
+          path: .coverage.*
+
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    needs:
+      - test
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox
+
+      - name: Retrieve test coverage
+        uses: actions/download-artifact@v2
+        with:
+          name: coverage
+
+      - name: Check coverage
+        run: tox -e coverage

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Django-Flags
 
 [![Build Status](https://github.com/cfpb/django-flags/workflows/test/badge.svg)](https://github.com/cfpb/django-flags/actions)
-[![Coverage Status](https://coveralls.io/repos/github/cfpb/django-flags/badge.svg?branch=main)](https://coveralls.io/github/cfpb/django-flags?branch=main)
 [![Ethical open source](https://img.shields.io/badge/ethical-open-%23bb8c3c?labelColor=393162)](https://ethicalsource.dev/principles/)
 
 Feature flags allow you to toggle functionality in both Django code and the Django templates based on configurable conditions. Flags can be useful for staging feature deployments, for A/B testing, or for any time you need an on/off switch for blocks of code. The toggle can be by date, user, URL value, or a number of [other conditions](https://cfpb.github.io/django-flags/conditions/), editable in the admin or in definable in settings.

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,11 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36,39}-dj{22,32},py39-dj40
+envlist=lint,py{36,39}-dj{22,32},py39-dj40,coverage
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
 commands=
-    coverage erase
-    coverage run --source='flags' {envbindir}/django-admin test {posargs}
-    coverage report -m
+    coverage run --parallel-mode --source='flags' {envbindir}/django-admin test {posargs}
 setenv=
     DJANGO_SETTINGS_MODULE=flags.tests.settings
 
@@ -31,6 +29,16 @@ commands=
     flake8 flags setup.py
     isort --check-only --diff flags
 
+[testenv:coverage]
+basepython=python3.9
+deps=
+    coverage
+    diff_cover
+commands=
+    coverage combine
+    coverage xml
+    diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
+
 [testenv:docs]
 basepython=python3.6
 deps=
@@ -45,7 +53,6 @@ exclude=
     __pycache__,
     flags/migrations/*
     flags/tests/testapp/migrations/*
-
 
 [isort]
 combine_as_imports=1


### PR DESCRIPTION
In [consumerfinance.gov](https://github.com/cfpb/consumerfinance.gov/blob/main/.github/workflows/backend.yml#L87-L127), we use `diff-cover` to measure coverage of a set of changes against `main`, and fail if the changes are not 100% covered. 

This PR brings our use of `diff-cover` into Django-Flags, with the intention to replace our use of Coveralls, which has been frustrating since our switch to GitHub Actions. It does this by adding a `coverage` env to tox and adding that env to the `envlist`. This means a full run through of our test matrix with `tox` locally will lint, run our tests, and then report out the difference in combined test coverage from all the matrix runs. 

I've added a new job to the `test` workflow in GitHub actions that will run that tox env.