### PR TITLE
Git ignore parallel coverage files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,7 @@ __pycache__/
 htmlcov/
 .tox/
 .coverage
+.coverage.*
 .cache
 nosetests.xml
 coverage.xml


### PR DESCRIPTION
These have names like `.coverage.<hostname>.<pid>.<random>`.