### PR TITLE
Anonymous users never match user conditions

### DIFF
--- a/flags/conditions/conditions.py
+++ b/flags/conditions/conditions.py
@@ -33,6 +33,9 @@ def user_condition(username, request=None, **kwargs):
     if request is None:
         raise RequiredForCondition("request is required for condition 'user'")
 
+    if request.user.is_anonymous:
+        return False
+
     return getattr(request.user, get_user_model().USERNAME_FIELD) == username
 
 

--- a/flags/tests/test_conditions_conditions.py
+++ b/flags/tests/test_conditions_conditions.py
@@ -58,6 +58,10 @@ class UserConditionTestCase(TestCase):
     def test_user_invalid(self):
         self.assertFalse(user_condition("nottestuser", request=self.request))
 
+    def test_user_anonymous(self):
+        self.request.user = AnonymousUser()
+        self.assertFalse(user_condition("somebody", request=self.request))
+
     def test_request_required(self):
         with self.assertRaises(RequiredForCondition):
             user_condition("testuser")
@@ -68,6 +72,11 @@ class UserConditionTestCase(TestCase):
         user.save()
         self.request.user = user
         self.assertTrue(user_condition("customuser", request=self.request))
+
+    @override_settings(AUTH_USER_MODEL="testapp.MyUserModel")
+    def test_custom_user_model_valid_anonymous(self):
+        self.request.user = AnonymousUser()
+        self.assertFalse(user_condition("somebody", request=self.request))
 
 
 class AnonymousConditionTestCase(TestCase):


### PR DESCRIPTION
AnonymousUser does not always have the USERNAME_FIELD attribute (for example it does not have an "email" field).

This fixes the following stacktrace:

```
  File "/usr/local/lib/python3.10/site-packages/flags/state.py", line 66, in flag_enabled
    return flag_state(flag_name, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/flags/state.py", line 61, in flag_state
    return _get_flag_state(flag_name, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/flags/state.py", line 13, in _get_flag_state
    return flag.check_state(**kwargs)
  File "/usr/local/lib/python3.10/site-packages/flags/sources.py", line 51, in check_state
    checked_conditions = [(c, c.check(**kwargs)) for c in self.conditions]
  File "/usr/local/lib/python3.10/site-packages/flags/sources.py", line 51, in <listcomp>
    checked_conditions = [(c, c.check(**kwargs)) for c in self.conditions]
  File "/usr/local/lib/python3.10/site-packages/flags/sources.py", line 27, in check
    return self.fn(self.value, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/flags/conditions/conditions.py", line 36, in user_condition
    return getattr(request.user, get_user_model().USERNAME_FIELD) == username
  File "/usr/local/lib/python3.10/site-packages/django/utils/functional.py", line 249, in inner
    return func(self._wrapped, *args)
AttributeError: 'AnonymousUser' object has no attribute 'email'
```