### PR TITLE
Add package links to PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ docs_extras = [
 setup(
     name="django-flags",
     url="https://github.com/cfpb/django-flags",
+    project_urls={
+        "Changelog": "https://cfpb.github.io/django-flags/releasenotes/",
+        "Documentation": "https://cfpb.github.io/django-flags/",
+    },
     author="CFPB",
     author_email="tech@cfpb.gov",
     description="Feature flags for Django projects",


### PR DESCRIPTION
Add two links to the sidebar on PyPI, to make it easier for folks to jump to the relevant pages. Example: https://pypi.org/project/django-htmx/ (PyPI adds the icons based on the link names).
