### PR TITLE
Support Jinja2 3.0+

### DIFF
--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Pending Release
+
+### 5.1.0
+
+- Support Jinja2 3.0+.
+
 ## 5.0.8
 
 ### What's new?

--- a/flags/jinja2tags.py
+++ b/flags/jinja2tags.py
@@ -1,7 +1,12 @@
-from jinja2 import contextfunction
 from jinja2.ext import Extension
 
 from flags.templatetags.feature_flags import flag_disabled, flag_enabled
+
+try:
+    # Jinja2 3.0+
+    from jinja2 import pass_context
+except ImportError:
+    from jinja2 import contextfunction as pass_context
 
 
 class FlagsExtension(Extension):
@@ -9,8 +14,8 @@ class FlagsExtension(Extension):
         super(FlagsExtension, self).__init__(environment)
         self.environment.globals.update(
             {
-                "flag_enabled": contextfunction(flag_enabled),
-                "flag_disabled": contextfunction(flag_disabled),
+                "flag_enabled": pass_context(flag_enabled),
+                "flag_disabled": pass_context(flag_disabled),
             }
         )
 


### PR DESCRIPTION
`contextfunction` was deprecated in 3.0.0 and removed in 3.1.0, in favour of a "unified" `pass_context` function for 'functions' and filters alike: https://jinja.palletsprojects.com/en/3.1.x/changes/