### PR TITLE
Drop support for Python 3.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,17 +32,17 @@ jobs:
     strategy:
       matrix:
         toxenv:
-            - py36-dj22
-            - py36-dj32
+            - py37-dj22
+            - py37-dj32
             - py39-dj22
             - py39-dj32
             - py39-dj40
             - py39-dj41
         include:
-          - toxenv: py36-dj22
-            python-version: 3.6
-          - toxenv: py36-dj32
-            python-version: 3.6
+          - toxenv: py37-dj22
+            python-version: 3.7
+          - toxenv: py37-dj32
+            python-version: 3.7
           - toxenv: py39-dj22
             python-version: 3.9
           - toxenv: py39-dj32

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Feature flags allow you to toggle functionality in both Django code and the Djan
 
 ## Dependencies
 
-- Python 3.6+
+- Python 3.7+
 - Django 2.2-4.0
 
 ## Installation

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ Feature flags allow you to toggle functionality in both Django code and the Djan
 ## Dependencies
 
 - Django 2.2, 3.0
-- Python 3.6+
+- Python 3.7+
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 79
-target-version = ['py36', 'py38']
+target-version = ['py37', 'py38']
 include = '\.pyi?$'
 exclude = '''
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     version="5.0.12",
     include_package_data=True,
     packages=find_packages(),
-    python_requires=">=3.6",
+    python_requires=">=3.7",
     install_requires=install_requires,
     extras_require={"testing": testing_extras, "docs": docs_extras},
     classifiers=[

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist=lint,py{36,39}-dj{22,32},py39-dj40,py39-dj41,coverage
+envlist=lint,py{37,39}-dj{22,32},py39-dj40,py39-dj41,coverage
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -10,7 +10,7 @@ setenv=
     DJANGO_SETTINGS_MODULE=flags.tests.settings
 
 basepython=
-    py36: python3.6
+    py37: python3.7
     py39: python3.9
 
 deps=
@@ -41,7 +41,7 @@ commands=
     diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
 
 [testenv:docs]
-basepython=python3.6
+basepython=python3.7
 deps=
     -e .[docs]
 commands=


### PR DESCRIPTION
Python 3.6 reached its end of life in December 2021, see https://peps.python.org/pep-0494/#lifespan