### PR TITLE
add django 4.x to supported django versions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Feature flags allow you to toggle functionality in both Django code and the Djan
 
 ## Dependencies
 
-- Django 2.2, 3.0
+- Django 2.2, 3.0, 4.x
 - Python 3.7+
 
 ## Installation


### PR DESCRIPTION
Hi, 
according to https://cfpb.github.io/django-flags/releasenotes/, Django 4.0 is supported since version 5.0.6, Django 4.1 since version 5.0.7 and Django 4.2 since version 5.0.13.

I thought it would be good to have that information also in the index.

Best, 

Diego