### PR TITLE
Run linters on Python 3.12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: '3.11'
+          python-version: '3.12'
 
       - name: Install dependencies
         run: |

--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ deps=
     dj42: Django>=4.2,<4.3
 
 [testenv:lint]
-basepython=python3.11
+basepython=python3.12
 deps=
     black
     flake8


### PR DESCRIPTION
Repeat of #109 with the latest and greatest Python.