### PR TITLE
Test on Django 5.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,7 @@ jobs:
             - py39-dj40
             - py39-dj41
             - py39-dj42
+            - py310-dj50
         include:
           - toxenv: py37-dj22
             python-version: 3.7
@@ -54,6 +55,8 @@ jobs:
             python-version: 3.9
           - toxenv: py39-dj42
             python-version: 3.9
+          - toxenv: py310-dj50
+            python-version: '3.10'
     steps:
       - uses: actions/checkout@v2
 

--- a/docs/releasenotes.md
+++ b/docs/releasenotes.md
@@ -4,6 +4,7 @@
 
 ### What's new?
 
+- Added Django 5.0 support (thanks [@adamchainz](https://github.com/adamchainz)!)
 
 ## 5.0.13
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         "Framework :: Django :: 4.0",
         "Framework :: Django :: 4.1",
         "Framework :: Django :: 4.2",
+        "Framework :: Django :: 5.0",
         "License :: CC0 1.0 Universal (CC0 1.0) Public Domain Dedication",
         "License :: Public Domain",
         "Programming Language :: Python",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,13 @@
 [tox]
 skipsdist=True
-envlist=lint,py{37,39}-dj{22,32},py39-dj40,py39-dj41,py39-dj42,coverage
+envlist=
+    lint
+    py{37,39}-dj{22,32}
+    py39-dj40
+    py39-dj41
+    py39-dj42
+    py310-dj50
+    coverage
 
 [testenv]
 install_command=pip install -e ".[testing]" -U {opts} {packages}
@@ -9,16 +16,13 @@ commands=
 setenv=
     DJANGO_SETTINGS_MODULE=flags.tests.settings
 
-basepython=
-    py37: python3.7
-    py39: python3.9
-
 deps=
     dj22: Django>=2.2,<2.3
     dj32: Django>=3.2,<3.3
     dj40: Django>=4.0,<4.1
     dj41: Django>=4.1,<4.2
     dj42: Django>=4.2,<4.3
+    dj50: Django>=5.0a1,<5.1
 
 [testenv:lint]
 basepython=python3.11


### PR DESCRIPTION
New Django is coming!

Copied where to change from #110.

Python 3.10 is the minimum for Django 5.0: https://docs.djangoproject.com/en/5.0/releases/5.0/ , so needed to bump up testing to use it.