### PR TITLE
Corrected link to API State

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -83,4 +83,4 @@ class FlaggedCodeTestCase(TestCase):
 ```
 
 
-See the [API reference](/api/state) for more details and examples.
+See the [API reference](/django-flags/api/state) for more details and examples.


### PR DESCRIPTION
Link was returning a 404 because of missing 'django-flags' in the path.