### PR TITLE
Skip user-condition validation when the auth table is missing

### DIFF
--- a/flags/conditions/validators.py
+++ b/flags/conditions/validators.py
@@ -3,6 +3,7 @@ import re
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
 from django.core.validators import RegexValidator
+from django.db import OperationalError, ProgrammingError
 from django.utils import dateparse
 
 from flags.utils import strtobool
@@ -45,6 +46,13 @@ def validate_user(value):
         UserModel.objects.get(**{UserModel.USERNAME_FIELD: value})
     except UserModel.DoesNotExist as err:
         raise ValidationError("Enter the username of a valid user.") from err
+    except (OperationalError, ProgrammingError):
+        # The user table may not exist yet, for example when the system checks
+        # run during a migration against a fresh database (before the auth
+        # tables are created). The username cannot be checked in that case, so
+        # skip validation rather than letting the database error abort the
+        # migration.
+        pass
 
 
 def validate_date(value):

--- a/flags/tests/test_conditions_validators.py
+++ b/flags/tests/test_conditions_validators.py
@@ -1,5 +1,8 @@
+from unittest import mock
+
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError
+from django.db import OperationalError, ProgrammingError
 from django.test import TestCase, override_settings
 
 from flags.conditions.validators import (
@@ -81,6 +84,19 @@ class ValidateUserTestCase(TestCase):
     def test_custom_user_invalid(self):
         with self.assertRaises(ValidationError):
             validate_user("nottestuser")
+
+    def test_user_table_missing_is_skipped(self):
+        # If the user table does not exist yet (for example when the system
+        # checks run during a migration against a fresh database), the lookup
+        # raises a database error. Validation should be skipped rather than
+        # letting that error abort the migration. See GH-96.
+        User = get_user_model()
+        for exc in (OperationalError, ProgrammingError):
+            with mock.patch.object(
+                User.objects, "get", side_effect=exc("relation does not exist")
+            ):
+                # Must not raise.
+                validate_user("testuser")
 
 
 class ValidateDateTestCase(TestCase):


### PR DESCRIPTION
Fixes #96.

`validate_user` does `UserModel.objects.get(...)`. That validator runs inside the `flag_conditions_check` system check, which only catches `ValidationError`. On a fresh database the system checks run *before* the auth tables are created (for example during the first `migrate`), so the lookup raises `OperationalError` / `ProgrammingError`, and since the check does not catch it, the error propagates and aborts the migration. The maintainer confirmed this in the thread, and a commenter suggested catching the database error.

This catches `OperationalError` / `ProgrammingError` in `validate_user` and skips validation in that case. The username cannot be checked when its table does not exist yet, and it is validated normally once the tables are in place, so the only behavior change is that a missing table no longer breaks `migrate`. I went with skipping rather than raising a `ValidationError`, since raising would surface a misleading "invalid value" warning on every migrate when the value is actually fine.

Added `test_user_table_missing_is_skipped`, which mocks the manager lookup to raise each error and asserts `validate_user` does not raise. Full `flags.tests.test_conditions_validators` suite passes (13 tests).